### PR TITLE
fix: conditional compilation for different Qt versions

### DIFF
--- a/xcb/windoweventhook.cpp
+++ b/xcb/windoweventhook.cpp
@@ -65,8 +65,13 @@ void WindowEventHook::init(QXcbWindow *window, bool redirectContent)
         VtableHook::overrideVfptrFun(window, &QXcbWindow::handleXIEnterLeave,
                                      &WindowEventHook::handleXIEnterLeave);
 #endif
+#if QT_VERSION < QT_VERSION_CHECK(5, 12, 0)
         VtableHook::overrideVfptrFun(window, &QPlatformWindow::windowEvent,
                                      &WindowEventHook::windowEvent);
+#else
+        VtableHook::overrideVfptrFun(window, &QXcbWindow::windowEvent,
+                                     &WindowEventHook::windowEvent);
+#endif
     }
 
     if (type == Qt::Window) {
@@ -559,10 +564,9 @@ void WindowEventHook::handleXIEnterLeave(QXcbWindow *window, xcb_ge_event_t *eve
 }
 
 #if QT_VERSION < QT_VERSION_CHECK(5, 12, 0)
-
 void WindowEventHook::windowEvent(QPlatformWindow *window, QEvent *event)
 #else
-bool WindowEventHook::windowEvent(QPlatformWindow *window, QEvent *event)
+bool WindowEventHook::windowEvent(QXcbWindow *window, QEvent *event)
 #endif
 {
     switch (event->type()) {


### PR DESCRIPTION
Qt版本不同时函数的参数不同，需修改成对应参数才能编译