### PR TITLE
fix: wayland下切换工作区，窗口隐藏

### DIFF
--- a/src/global.h
+++ b/src/global.h
@@ -59,6 +59,7 @@ DEFINE_CONST_CHAR(popupSystemWindowMenu);
 DEFINE_CONST_CHAR(groupLeader);
 DEFINE_CONST_CHAR(noTitlebar);
 DEFINE_CONST_CHAR(enableGLPaint);
+DEFINE_CONST_CHAR(windowInWorkSpace);
 
 // functions
 DEFINE_CONST_CHAR(setWmBlurWindowBackgroundArea);

--- a/wayland/wayland-shell/dwaylandshellmanager.cpp
+++ b/wayland/wayland-shell/dwaylandshellmanager.cpp
@@ -158,6 +158,10 @@ void DWaylandShellManager::sendProperty(QWaylandShellSurface *self, const QStrin
             wlWindow->window()->setProperty(supportForSplittingWindow, dde_shell_surface->isSplitable());
             return;
         }
+        if (!name.compare(windowInWorkSpace)) {
+            dde_shell_surface->requestOnAllDesktops(value.toBool());
+            qCDebug(dwlp()) << "### requestOnAllDesktops" << name << value;
+        }
     }
 
     // 将popup的窗口设置为tooltop层级, 包括qmenu，combobox弹出窗口


### PR DESCRIPTION
1. 增加windowInWorkArea属性
2. 创建PlasmaWindowManagement对象
3. 将属性windowInWorkSpace传给窗管处理

Log: 修复wayland下切换工作区，窗口隐藏问题
Bug: https://pms.uniontech.com/bug-view-109805.html
Influence: wayland 切换工作区窗口隐藏