### PR TITLE
feat: wayland平台窗口模糊效果适配

### DIFF
--- a/wayland/dwayland/dwaylandinterfacehook.cpp
+++ b/wayland/dwayland/dwaylandinterfacehook.cpp
@@ -99,6 +99,8 @@ static QFunctionPointer getFunction(const QByteArray &function)
         return reinterpret_cast<QFunctionPointer>(&DWaylandInterfaceHook::splitWindowOnScreen);
     } else if (function == supportForSplittingWindow) {
         return reinterpret_cast<QFunctionPointer>(&DWaylandInterfaceHook::supportForSplittingWindow);
+    } else if (function == enableBlurWindow) {
+        return reinterpret_cast<QFunctionPointer>(&DWaylandInterfaceHook::enableBlurWindow);
     }
 
     return nullptr;
@@ -281,6 +283,16 @@ bool DWaylandInterfaceHook::supportForSplittingWindow(WId wid)
         return false;
     DNoTitlebarWlWindowHelper::setWindowProperty(window, ::supportForSplittingWindow, false);
     return window->property(::supportForSplittingWindow).toBool();
+}
+
+bool DWaylandInterfaceHook::enableBlurWindow(WId wid, bool enable)
+{
+    QWindow *window = fromQtWinId(wid);
+    if(!window || !window->handle())
+        return false;
+
+    DNoTitlebarWlWindowHelper::setWindowProperty(window, ::enableBlurWindow, enable);
+    return window->property(::enableBlurWindow).toBool();
 }
 
 DXcbXSettings *DWaylandInterfaceHook::globalSettings()

--- a/wayland/dwayland/dwaylandinterfacehook.h
+++ b/wayland/dwayland/dwaylandinterfacehook.h
@@ -54,6 +54,7 @@ public:
     static bool isEnableDwayland(const QWindow *window);
     static void splitWindowOnScreen(WId wid, quint32 type);
     static bool supportForSplittingWindow(WId wid);
+    static bool enableBlurWindow(WId wid, bool enable);
     static DXcbXSettings *globalSettings();
 
 private:

--- a/wayland/wayland-shell/dwaylandshellmanager.h
+++ b/wayland/wayland-shell/dwaylandshellmanager.h
@@ -20,6 +20,10 @@
 #include <KWayland/Client/ddekeyboard.h>
 #include <KWayland/Client/strut.h>
 #include <KWayland/Client/fakeinput.h>
+#include <KWayland/Client/blur.h>
+#include <KWayland/Client/region.h>
+#include <KWayland/Client/surface.h>
+#include <KWayland/Client/compositor.h>
 
 #include <QGuiApplication>
 #include <QPointer>
@@ -52,6 +56,8 @@ public:
     static void createDDEShell(KWayland::Client::Registry *registry, quint32 name, quint32 version);
     static void createDDESeat(KWayland::Client::Registry *registry, quint32 name, quint32 version);
     static void createStrut(KWayland::Client::Registry *registry, quint32 name, quint32 version);
+    static void createBlur(KWayland::Client::Registry *registry, quint32 name, quint32 version);
+    static void createCompositor(KWayland::Client::Registry *registry, quint32 name, quint32 version);
     static void createDDEPointer(KWayland::Client::Registry *registry);
     static void createDDEKeyboard(KWayland::Client::Registry *registry);
     static void createDDEFakeInput(KWayland::Client::Registry *registry);
@@ -60,6 +66,7 @@ public:
     static void setWindowStaysOnTop(QWaylandShellSurface *surface, const bool state);
     static void setDockStrut(QWaylandShellSurface *surface, const QVariant var);
     static void setCursorPoint(QPointF pos);
+    static QMap<QWaylandWindow *, QPair<KWayland::Client::Blur *, KWayland::Client::Region*>> w2blur;
 };
 
 }

--- a/wayland/wayland-shell/main.cpp
+++ b/wayland/wayland-shell/main.cpp
@@ -84,6 +84,13 @@ QWaylandShellIntegration *QKWaylandShellIntegrationPlugin::create(const QString 
        DWaylandShellManager::createStrut(registry, name, version);
     });
 
+    connect(registry, &KWayland::Client::Registry::blurAnnounced, [registry](quint32 name, quint32 version) {
+        DWaylandShellManager::createBlur(registry, name, version);
+    });
+    QObject::connect(registry, &KWayland::Client::Registry::compositorAnnounced, [registry](quint32 name, quint32 version){
+        DWaylandShellManager::createCompositor(registry, name, version);
+    });
+
     registry->setup();
 
     wl_display_roundtrip(wlDisplay);


### PR DESCRIPTION
当窗口设置了 Qt::WA_TranslucentBackground 属性的时候对其应用模糊效果

Log: wayland 平台支持窗口模糊效果
Influence: 所有具有透明属性并主动设置了模糊效果的窗口