### PR TITLE
chore: 非tooltip菜单无法显示的问题优化

### DIFF
--- a/wayland/wayland-shell/dwaylandshellmanager.cpp
+++ b/wayland/wayland-shell/dwaylandshellmanager.cpp
@@ -669,8 +669,8 @@ void DWaylandShellManager::handleWindowStateChanged(QWaylandWindow *window)
 
     //    STATE_CHANGED(activeChanged);
     QObject::connect(ddeShellSurface, &KCDFace::activeChanged, window, [window, ddeShellSurface](){
-        QWindow *w = ddeShellSurface->isActive() ? window->window() : nullptr;
-        QWindowSystemInterface::handleWindowActivated(w, Qt::FocusReason::ActiveWindowFocusReason);
+        if (QWindow *w = ddeShellSurface->isActive() ? window->window() : nullptr)
+            QWindowSystemInterface::handleWindowActivated(w, Qt::FocusReason::ActiveWindowFocusReason);
     });
 
 #define SYNC_FLAG(sig, enableFunc, flag) \


### PR DESCRIPTION
如果菜单不是tootip的role,显示时会一闪就关闭,因为收到两次activeChanged,
一次为null一次为menu，导致菜单显示后立即被关闭

Log:
Influence: wayland环境的右键菜单