### PR TITLE
Add Qt 5.15.4 headers

### DIFF
--- a/xcb/libqt5xcbqpa-dev/5.15.4/qxcbatom.h
+++ b/xcb/libqt5xcbqpa-dev/5.15.4/qxcbatom.h
@@ -1,0 +1,259 @@
+/****************************************************************************
+**
+** Copyright (C) 2018 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of the QtCore module of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 2.0 or (at your option) the GNU General
+** Public license version 3 or any later version approved by the KDE Free
+** Qt Foundation. The licenses are as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
+** included in the packaging of this file. Please review the following
+** information to ensure the GNU General Public License requirements will
+** be met: https://www.gnu.org/licenses/gpl-2.0.html and
+** https://www.gnu.org/licenses/gpl-3.0.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+#ifndef QXCBATOM_H
+#define QXCBATOM_H
+
+#include <xcb/xcb.h>
+
+class QXcbAtom
+{
+public:
+    enum Atom {
+        // window-manager <-> client protocols
+        WM_PROTOCOLS,
+        WM_DELETE_WINDOW,
+        WM_TAKE_FOCUS,
+        _NET_WM_PING,
+        _NET_WM_CONTEXT_HELP,
+        _NET_WM_SYNC_REQUEST,
+        _NET_WM_SYNC_REQUEST_COUNTER,
+        MANAGER, // System tray notification
+        _NET_SYSTEM_TRAY_OPCODE, // System tray operation
+
+        // ICCCM window state
+        WM_STATE,
+        WM_CHANGE_STATE,
+        WM_CLASS,
+        WM_NAME,
+
+        // Session management
+        WM_CLIENT_LEADER,
+        WM_WINDOW_ROLE,
+        SM_CLIENT_ID,
+        WM_CLIENT_MACHINE,
+
+        // Clipboard
+        CLIPBOARD,
+        INCR,
+        TARGETS,
+        MULTIPLE,
+        TIMESTAMP,
+        SAVE_TARGETS,
+        CLIP_TEMPORARY,
+        _QT_SELECTION,
+        _QT_CLIPBOARD_SENTINEL,
+        _QT_SELECTION_SENTINEL,
+        CLIPBOARD_MANAGER,
+
+        RESOURCE_MANAGER,
+
+        _XSETROOT_ID,
+
+        _QT_SCROLL_DONE,
+        _QT_INPUT_ENCODING,
+
+        // Qt/XCB specific
+        _QT_CLOSE_CONNECTION,
+
+        _MOTIF_WM_HINTS,
+
+        DTWM_IS_RUNNING,
+        ENLIGHTENMENT_DESKTOP,
+        _DT_SAVE_MODE,
+        _SGI_DESKS_MANAGER,
+
+        // EWMH (aka NETWM)
+        _NET_SUPPORTED,
+        _NET_VIRTUAL_ROOTS,
+        _NET_WORKAREA,
+
+        _NET_MOVERESIZE_WINDOW,
+        _NET_WM_MOVERESIZE,
+
+        _NET_WM_NAME,
+        _NET_WM_ICON_NAME,
+        _NET_WM_ICON,
+
+        _NET_WM_PID,
+
+        _NET_WM_WINDOW_OPACITY,
+
+        _NET_WM_STATE,
+        _NET_WM_STATE_ABOVE,
+        _NET_WM_STATE_BELOW,
+        _NET_WM_STATE_FULLSCREEN,
+        _NET_WM_STATE_MAXIMIZED_HORZ,
+        _NET_WM_STATE_MAXIMIZED_VERT,
+        _NET_WM_STATE_MODAL,
+        _NET_WM_STATE_STAYS_ON_TOP,
+        _NET_WM_STATE_DEMANDS_ATTENTION,
+        _NET_WM_STATE_HIDDEN,
+
+        _NET_WM_USER_TIME,
+        _NET_WM_USER_TIME_WINDOW,
+        _NET_WM_FULL_PLACEMENT,
+
+        _NET_WM_WINDOW_TYPE,
+        _NET_WM_WINDOW_TYPE_DESKTOP,
+        _NET_WM_WINDOW_TYPE_DOCK,
+        _NET_WM_WINDOW_TYPE_TOOLBAR,
+        _NET_WM_WINDOW_TYPE_MENU,
+        _NET_WM_WINDOW_TYPE_UTILITY,
+        _NET_WM_WINDOW_TYPE_SPLASH,
+        _NET_WM_WINDOW_TYPE_DIALOG,
+        _NET_WM_WINDOW_TYPE_DROPDOWN_MENU,
+        _NET_WM_WINDOW_TYPE_POPUP_MENU,
+        _NET_WM_WINDOW_TYPE_TOOLTIP,
+        _NET_WM_WINDOW_TYPE_NOTIFICATION,
+        _NET_WM_WINDOW_TYPE_COMBO,
+        _NET_WM_WINDOW_TYPE_DND,
+        _NET_WM_WINDOW_TYPE_NORMAL,
+        _KDE_NET_WM_WINDOW_TYPE_OVERRIDE,
+
+        _KDE_NET_WM_FRAME_STRUT,
+        _NET_FRAME_EXTENTS,
+
+        _NET_STARTUP_INFO,
+        _NET_STARTUP_INFO_BEGIN,
+
+        _NET_SUPPORTING_WM_CHECK,
+
+        _NET_WM_CM_S0,
+
+        _NET_SYSTEM_TRAY_VISUAL,
+
+        _NET_ACTIVE_WINDOW,
+
+        // Property formats
+        TEXT,
+        UTF8_STRING,
+        CARDINAL,
+
+        // Xdnd
+        XdndEnter,
+        XdndPosition,
+        XdndStatus,
+        XdndLeave,
+        XdndDrop,
+        XdndFinished,
+        XdndTypelist,
+        XdndActionList,
+
+        XdndSelection,
+
+        XdndAware,
+        XdndProxy,
+
+        XdndActionCopy,
+        XdndActionLink,
+        XdndActionMove,
+        XdndActionAsk,
+        XdndActionPrivate,
+
+        // Xkb
+        _XKB_RULES_NAMES,
+
+        // XEMBED
+        _XEMBED,
+        _XEMBED_INFO,
+
+        // XInput2
+        ButtonLeft,
+        ButtonMiddle,
+        ButtonRight,
+        ButtonWheelUp,
+        ButtonWheelDown,
+        ButtonHorizWheelLeft,
+        ButtonHorizWheelRight,
+        AbsMTPositionX,
+        AbsMTPositionY,
+        AbsMTTouchMajor,
+        AbsMTTouchMinor,
+        AbsMTOrientation,
+        AbsMTPressure,
+        AbsMTTrackingID,
+        MaxContacts,
+        RelX,
+        RelY,
+        // XInput2 tablet
+        AbsX,
+        AbsY,
+        AbsPressure,
+        AbsTiltX,
+        AbsTiltY,
+        AbsWheel,
+        AbsDistance,
+        WacomSerialIDs,
+        INTEGER,
+        RelHorizWheel,
+        RelVertWheel,
+        RelHorizScroll,
+        RelVertScroll,
+
+        _XSETTINGS_SETTINGS,
+
+        _COMPIZ_DECOR_PENDING,
+        _COMPIZ_DECOR_REQUEST,
+        _COMPIZ_DECOR_DELETE_PIXMAP,
+        _COMPIZ_TOOLKIT_ACTION,
+        _GTK_LOAD_ICONTHEMES,
+
+        AT_SPI_BUS,
+
+        EDID,
+        EDID_DATA,
+        XFree86_DDC_EDID1_RAWDATA,
+
+        NAtoms
+    };
+
+    QXcbAtom();
+    void initialize(xcb_connection_t *connection);
+
+    inline xcb_atom_t atom(QXcbAtom::Atom atom) const { return m_allAtoms[atom]; }
+    QXcbAtom::Atom qatom(xcb_atom_t atom) const;
+
+protected:
+    void initializeAllAtoms(xcb_connection_t *connection);
+
+private:
+    xcb_atom_t m_allAtoms[QXcbAtom::NAtoms];
+};
+
+#endif // QXCBATOM_H

--- a/xcb/libqt5xcbqpa-dev/5.15.4/qxcbbackingstore.h
+++ b/xcb/libqt5xcbqpa-dev/5.15.4/qxcbbackingstore.h
@@ -1,0 +1,116 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of the plugins of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 2.0 or (at your option) the GNU General
+** Public license version 3 or any later version approved by the KDE Free
+** Qt Foundation. The licenses are as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
+** included in the packaging of this file. Please review the following
+** information to ensure the GNU General Public License requirements will
+** be met: https://www.gnu.org/licenses/gpl-2.0.html and
+** https://www.gnu.org/licenses/gpl-3.0.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef QXCBBACKINGSTORE_H
+#define QXCBBACKINGSTORE_H
+
+#include <qpa/qplatformbackingstore.h>
+#include <QtCore/QStack>
+
+#include <xcb/xcb.h>
+
+#include "qxcbobject.h"
+
+QT_BEGIN_NAMESPACE
+
+class QXcbBackingStoreImage;
+
+class QXcbBackingStore : public QXcbObject, public QPlatformBackingStore
+{
+public:
+    QXcbBackingStore(QWindow *window);
+    ~QXcbBackingStore();
+
+    QPaintDevice *paintDevice() override;
+    void flush(QWindow *window, const QRegion &region, const QPoint &offset) override;
+#ifndef QT_NO_OPENGL
+    void composeAndFlush(QWindow *window, const QRegion &region, const QPoint &offset,
+                         QPlatformTextureList *textures,
+                         bool translucentBackground) override;
+#endif
+    QImage toImage() const override;
+
+    QPlatformGraphicsBuffer *graphicsBuffer() const override;
+
+    void resize(const QSize &size, const QRegion &staticContents) override;
+    bool scroll(const QRegion &area, int dx, int dy) override;
+
+    void beginPaint(const QRegion &) override;
+    void endPaint() override;
+
+    static bool createSystemVShmSegment(xcb_connection_t *c, size_t segmentSize = 1,
+                                        void *shmInfo = nullptr);
+
+protected:
+    virtual void render(xcb_window_t window, const QRegion &region, const QPoint &offset);
+    virtual void recreateImage(QXcbWindow *win, const QSize &size);
+
+    QXcbBackingStoreImage *m_image = nullptr;
+    QStack<QRegion> m_paintRegions;
+    QImage m_rgbImage;
+};
+
+class QXcbSystemTrayBackingStore : public QXcbBackingStore
+{
+public:
+    QXcbSystemTrayBackingStore(QWindow *window);
+    ~QXcbSystemTrayBackingStore();
+
+    void beginPaint(const QRegion &) override;
+
+protected:
+    void render(xcb_window_t window, const QRegion &region, const QPoint &offset) override;
+    void recreateImage(QXcbWindow *win, const QSize &size) override;
+
+private:
+    void initXRenderMode();
+
+    xcb_pixmap_t m_xrenderPixmap = XCB_NONE;
+    xcb_render_picture_t m_xrenderPicture = XCB_NONE;
+    xcb_render_pictformat_t m_xrenderPictFormat  = XCB_NONE;
+    xcb_render_picture_t m_windowPicture = XCB_NONE;
+
+    bool m_usingXRenderMode = false;
+    bool m_useGrabbedBackgound = false;
+    QPixmap m_grabbedBackground;
+};
+
+QT_END_NAMESPACE
+
+#endif

--- a/xcb/libqt5xcbqpa-dev/5.15.4/qxcbclipboard.h
+++ b/xcb/libqt5xcbqpa-dev/5.15.4/qxcbclipboard.h
@@ -1,0 +1,152 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of the plugins of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 2.0 or (at your option) the GNU General
+** Public license version 3 or any later version approved by the KDE Free
+** Qt Foundation. The licenses are as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
+** included in the packaging of this file. Please review the following
+** information to ensure the GNU General Public License requirements will
+** be met: https://www.gnu.org/licenses/gpl-2.0.html and
+** https://www.gnu.org/licenses/gpl-3.0.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef QXCBCLIPBOARD_H
+#define QXCBCLIPBOARD_H
+
+#include <qpa/qplatformclipboard.h>
+#include <qxcbobject.h>
+#include <xcb/xcb.h>
+#include <xcb/xfixes.h>
+
+#include <QtCore/QObject>
+
+QT_BEGIN_NAMESPACE
+
+#ifndef QT_NO_CLIPBOARD
+
+class QXcbConnection;
+class QXcbScreen;
+class QXcbClipboard;
+class QXcbClipboardMime;
+
+class QXcbClipboardTransaction : public QObject
+{
+    Q_OBJECT
+public:
+    QXcbClipboardTransaction(QXcbClipboard *clipboard, xcb_window_t w, xcb_atom_t p,
+                           QByteArray d, xcb_atom_t t, int f);
+    ~QXcbClipboardTransaction();
+
+    bool updateIncrementalProperty(const xcb_property_notify_event_t *event);
+
+protected:
+    void timerEvent(QTimerEvent *ev) override;
+
+private:
+    QXcbClipboard *m_clipboard;
+    xcb_window_t m_window;
+    xcb_atom_t m_property;
+    QByteArray m_data;
+    xcb_atom_t m_target;
+    uint8_t m_format;
+    uint m_offset = 0;
+    int m_abortTimerId = 0;
+};
+
+class QXcbClipboard : public QXcbObject, public QPlatformClipboard
+{
+public:
+    QXcbClipboard(QXcbConnection *connection);
+    ~QXcbClipboard();
+
+    QMimeData *mimeData(QClipboard::Mode mode) override;
+    void setMimeData(QMimeData *data, QClipboard::Mode mode) override;
+
+    bool supportsMode(QClipboard::Mode mode) const override;
+    bool ownsMode(QClipboard::Mode mode) const override;
+
+    QXcbScreen *screen() const;
+
+    xcb_window_t requestor() const;
+    void setRequestor(xcb_window_t window);
+
+    xcb_window_t owner() const;
+
+    void handleSelectionRequest(xcb_selection_request_event_t *event);
+    void handleSelectionClearRequest(xcb_selection_clear_event_t *event);
+    void handleXFixesSelectionRequest(xcb_xfixes_selection_notify_event_t *event);
+
+    bool clipboardReadProperty(xcb_window_t win, xcb_atom_t property, bool deleteProperty, QByteArray *buffer, int *size, xcb_atom_t *type, int *format);
+    QByteArray clipboardReadIncrementalProperty(xcb_window_t win, xcb_atom_t property, int nbytes, bool nullterm);
+
+    QByteArray getDataInFormat(xcb_atom_t modeAtom, xcb_atom_t fmtatom);
+
+    bool handlePropertyNotify(const xcb_generic_event_t *event);
+
+    xcb_window_t getSelectionOwner(xcb_atom_t atom) const;
+    QByteArray getSelection(xcb_atom_t selection, xcb_atom_t target, xcb_atom_t property, xcb_timestamp_t t = 0);
+
+    int increment() const { return m_maxPropertyRequestDataBytes; }
+    int clipboardTimeout() const { return clipboard_timeout; }
+
+    void removeTransaction(xcb_window_t window) { m_transactions.remove(window); }
+
+private:
+    xcb_generic_event_t *waitForClipboardEvent(xcb_window_t window, int type, bool checkManager = false);
+
+    xcb_atom_t sendTargetsSelection(QMimeData *d, xcb_window_t window, xcb_atom_t property);
+    xcb_atom_t sendSelection(QMimeData *d, xcb_atom_t target, xcb_window_t window, xcb_atom_t property);
+
+    xcb_atom_t atomForMode(QClipboard::Mode mode) const;
+    QClipboard::Mode modeForAtom(xcb_atom_t atom) const;
+
+    // Selection and Clipboard
+    QScopedPointer<QXcbClipboardMime> m_xClipboard[2];
+    QMimeData *m_clientClipboard[2];
+    xcb_timestamp_t m_timestamp[2];
+
+    xcb_window_t m_requestor = XCB_NONE;
+    xcb_window_t m_owner = XCB_NONE;
+
+    static const int clipboard_timeout;
+
+    int m_maxPropertyRequestDataBytes = 0;
+    bool m_clipboard_closing = false;
+    xcb_timestamp_t m_incr_receive_time = 0;
+
+    using TransactionMap = QMap<xcb_window_t, QXcbClipboardTransaction *>;
+    TransactionMap m_transactions;
+};
+
+#endif // QT_NO_CLIPBOARD
+
+QT_END_NAMESPACE
+
+#endif // QXCBCLIPBOARD_H

--- a/xcb/libqt5xcbqpa-dev/5.15.4/qxcbconnection.h
+++ b/xcb/libqt5xcbqpa-dev/5.15.4/qxcbconnection.h
@@ -1,0 +1,409 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of the plugins of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 2.0 or (at your option) the GNU General
+** Public license version 3 or any later version approved by the KDE Free
+** Qt Foundation. The licenses are as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
+** included in the packaging of this file. Please review the following
+** information to ensure the GNU General Public License requirements will
+** be met: https://www.gnu.org/licenses/gpl-2.0.html and
+** https://www.gnu.org/licenses/gpl-3.0.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef QXCBCONNECTION_H
+#define QXCBCONNECTION_H
+
+#include <xcb/xcb.h>
+#include <xcb/randr.h>
+
+#include <QtCore/QTimer>
+#include <QtGui/private/qtguiglobal_p.h>
+#include "qxcbexport.h"
+#include <QHash>
+#include <QList>
+#include <QVector>
+#include <qpa/qwindowsysteminterface.h>
+#include <QtCore/QLoggingCategory>
+#include <QtCore/private/qglobal_p.h>
+
+#include "qxcbeventqueue.h"
+#include "qxcbconnection_basic.h"
+
+#if QT_CONFIG(tabletevent)
+#include <QTabletEvent>
+#endif
+
+QT_BEGIN_NAMESPACE
+
+Q_DECLARE_LOGGING_CATEGORY(lcQpaXInput)
+Q_DECLARE_LOGGING_CATEGORY(lcQpaXInputDevices)
+Q_DECLARE_LOGGING_CATEGORY(lcQpaXInputEvents)
+Q_DECLARE_LOGGING_CATEGORY(lcQpaScreen)
+Q_DECLARE_LOGGING_CATEGORY(lcQpaEvents)
+Q_DECLARE_LOGGING_CATEGORY(lcQpaPeeker)
+Q_DECLARE_LOGGING_CATEGORY(lcQpaKeyboard)
+Q_DECLARE_LOGGING_CATEGORY(lcQpaClipboard)
+Q_DECLARE_LOGGING_CATEGORY(lcQpaXDnd)
+Q_DECLARE_LOGGING_CATEGORY(lcQpaEventReader)
+
+class QXcbVirtualDesktop;
+class QXcbScreen;
+class QXcbWindow;
+class QXcbDrag;
+class QXcbKeyboard;
+class QXcbClipboard;
+class QXcbWMSupport;
+class QXcbNativeInterface;
+class QXcbSystemTrayTracker;
+class QXcbGlIntegration;
+
+class QXcbWindowEventListener
+{
+public:
+    virtual ~QXcbWindowEventListener() {}
+    virtual bool handleNativeEvent(xcb_generic_event_t *) { return false; }
+
+    virtual void handleExposeEvent(const xcb_expose_event_t *) {}
+    virtual void handleClientMessageEvent(const xcb_client_message_event_t *) {}
+    virtual void handleConfigureNotifyEvent(const xcb_configure_notify_event_t *) {}
+    virtual void handleMapNotifyEvent(const xcb_map_notify_event_t *) {}
+    virtual void handleUnmapNotifyEvent(const xcb_unmap_notify_event_t *) {}
+    virtual void handleDestroyNotifyEvent(const xcb_destroy_notify_event_t *) {}
+    virtual void handleButtonPressEvent(const xcb_button_press_event_t *) {}
+    virtual void handleButtonReleaseEvent(const xcb_button_release_event_t *) {}
+    virtual void handleMotionNotifyEvent(const xcb_motion_notify_event_t *) {}
+    virtual void handleEnterNotifyEvent(const xcb_enter_notify_event_t *) {}
+    virtual void handleLeaveNotifyEvent(const xcb_leave_notify_event_t *) {}
+    virtual void handleFocusInEvent(const xcb_focus_in_event_t *) {}
+    virtual void handleFocusOutEvent(const xcb_focus_out_event_t *) {}
+    virtual void handlePropertyNotifyEvent(const xcb_property_notify_event_t *) {}
+    virtual void handleXIMouseEvent(xcb_ge_event_t *, Qt::MouseEventSource = Qt::MouseEventNotSynthesized) {}
+    virtual void handleXIEnterLeave(xcb_ge_event_t *) {}
+    virtual QXcbWindow *toWindow() { return nullptr; }
+};
+
+typedef QHash<xcb_window_t, QXcbWindowEventListener *> WindowMapper;
+
+class QXcbSyncWindowRequest : public QEvent
+{
+public:
+    QXcbSyncWindowRequest(QXcbWindow *w) : QEvent(QEvent::Type(QEvent::User + 1)), m_window(w) { }
+
+    QXcbWindow *window() const { return m_window; }
+    void invalidate();
+
+private:
+    QXcbWindow *m_window;
+};
+
+class Q_XCB_EXPORT QXcbConnection : public QXcbBasicConnection
+{
+    Q_OBJECT
+public:
+    QXcbConnection(QXcbNativeInterface *nativeInterface, bool canGrabServer, xcb_visualid_t defaultVisualId, const char *displayName = nullptr);
+    ~QXcbConnection();
+
+    QXcbConnection *connection() const { return const_cast<QXcbConnection *>(this); }
+    QXcbEventQueue *eventQueue() const { return m_eventQueue; }
+
+    const QList<QXcbVirtualDesktop *> &virtualDesktops() const { return m_virtualDesktops; }
+    const QList<QXcbScreen *> &screens() const { return m_screens; }
+    QXcbVirtualDesktop *primaryVirtualDesktop() const {
+        return m_virtualDesktops.value(primaryScreenNumber());
+    }
+    QXcbScreen *primaryScreen() const;
+
+    const xcb_format_t *formatForDepth(uint8_t depth) const;
+
+    bool imageNeedsEndianSwap() const
+    {
+        if (!hasShm())
+            return false; // The non-Shm path does its own swapping
+#if Q_BYTE_ORDER == Q_BIG_ENDIAN
+        return setup()->image_byte_order != XCB_IMAGE_ORDER_MSB_FIRST;
+#else
+        return setup()->image_byte_order != XCB_IMAGE_ORDER_LSB_FIRST;
+#endif
+    }
+
+    QXcbKeyboard *keyboard() const { return m_keyboard; }
+
+#ifndef QT_NO_CLIPBOARD
+    QXcbClipboard *clipboard() const { return m_clipboard; }
+#endif
+#if QT_CONFIG(draganddrop)
+    QXcbDrag *drag() const { return m_drag; }
+#endif
+
+    QXcbWMSupport *wmSupport() const { return m_wmSupport.data(); }
+    xcb_window_t rootWindow();
+    xcb_window_t clientLeader();
+
+    bool hasDefaultVisualId() const { return m_defaultVisualId != UINT_MAX; }
+    xcb_visualid_t defaultVisualId() const { return m_defaultVisualId; }
+
+    void sync();
+
+    void handleXcbError(xcb_generic_error_t *error);
+    void printXcbError(const char *message, xcb_generic_error_t *error);
+    void handleXcbEvent(xcb_generic_event_t *event);
+    void printXcbEvent(const QLoggingCategory &log, const char *message,
+                       xcb_generic_event_t *event) const;
+
+    void addWindowEventListener(xcb_window_t id, QXcbWindowEventListener *eventListener);
+    void removeWindowEventListener(xcb_window_t id);
+    QXcbWindowEventListener *windowEventListenerFromId(xcb_window_t id);
+    QXcbWindow *platformWindowFromId(xcb_window_t id);
+
+    inline xcb_timestamp_t time() const { return m_time; }
+    inline void setTime(xcb_timestamp_t t) { if (timeGreaterThan(t, m_time)) m_time = t; }
+
+    inline xcb_timestamp_t netWmUserTime() const { return m_netWmUserTime; }
+    inline void setNetWmUserTime(xcb_timestamp_t t) { if (timeGreaterThan(t, m_netWmUserTime)) m_netWmUserTime = t; }
+
+    xcb_timestamp_t getTimestamp();
+    xcb_window_t getSelectionOwner(xcb_atom_t atom) const;
+    xcb_window_t getQtSelectionOwner();
+
+    void setButtonState(Qt::MouseButton button, bool down);
+    Qt::MouseButtons buttonState() const { return m_buttonState; }
+    Qt::MouseButton button() const { return m_button; }
+    Qt::MouseButton translateMouseButton(xcb_button_t s);
+
+    QXcbWindow *focusWindow() const { return m_focusWindow; }
+    void setFocusWindow(QWindow *);
+    QXcbWindow *mouseGrabber() const { return m_mouseGrabber; }
+    void setMouseGrabber(QXcbWindow *);
+    QXcbWindow *mousePressWindow() const { return m_mousePressWindow; }
+    void setMousePressWindow(QXcbWindow *);
+
+    QByteArray startupId() const { return m_startupId; }
+    void setStartupId(const QByteArray &nextId) { m_startupId = nextId; }
+    void clearStartupId() { m_startupId.clear(); }
+
+    void grabServer();
+    void ungrabServer();
+
+    bool isUnity() const { return m_xdgCurrentDesktop == "unity"; }
+    bool isGnome() const { return m_xdgCurrentDesktop == "gnome"; }
+
+    QXcbNativeInterface *nativeInterface() const { return m_nativeInterface; }
+
+    QXcbSystemTrayTracker *systemTrayTracker() const;
+
+    Qt::MouseButtons queryMouseButtons() const;
+    Qt::KeyboardModifiers queryKeyboardModifiers() const;
+
+    bool isUserInputEvent(xcb_generic_event_t *event) const;
+
+    void xi2SelectStateEvents();
+    void xi2SelectDeviceEvents(xcb_window_t window);
+    void xi2SelectDeviceEventsCompatibility(xcb_window_t window);
+    bool xi2SetMouseGrabEnabled(xcb_window_t w, bool grab);
+    bool xi2MouseEventsDisabled() const;
+    Qt::MouseButton xiToQtMouseButton(uint32_t b);
+    void xi2UpdateScrollingDevices();
+    bool startSystemMoveResizeForTouch(xcb_window_t window, int edges);
+    void abortSystemMoveResizeForTouch();
+    bool isTouchScreen(int id);
+
+    bool canGrab() const { return m_canGrabServer; }
+
+    QXcbGlIntegration *glIntegration() const;
+
+    void flush() { xcb_flush(xcb_connection()); }
+    void processXcbEvents(QEventLoop::ProcessEventsFlags flags);
+
+    QTimer &focusInTimer() { return m_focusInTimer; }
+
+protected:
+    bool event(QEvent *e) override;
+
+private:
+    void xrandrSelectEvents();
+    QXcbScreen* findScreenForCrtc(xcb_window_t rootWindow, xcb_randr_crtc_t crtc) const;
+    QXcbScreen* findScreenForOutput(xcb_window_t rootWindow, xcb_randr_output_t output) const;
+    QXcbVirtualDesktop* virtualDesktopForRootWindow(xcb_window_t rootWindow) const;
+    void updateScreens(const xcb_randr_notify_event_t *event);
+    bool checkOutputIsPrimary(xcb_window_t rootWindow, xcb_randr_output_t output);
+    void updateScreen(QXcbScreen *screen, const xcb_randr_output_change_t &outputChange);
+    QXcbScreen *createScreen(QXcbVirtualDesktop *virtualDesktop,
+                             const xcb_randr_output_change_t &outputChange,
+                             xcb_randr_get_output_info_reply_t *outputInfo);
+    void destroyScreen(QXcbScreen *screen);
+    void initializeScreens();
+    bool compressEvent(xcb_generic_event_t *event) const;
+    inline bool timeGreaterThan(xcb_timestamp_t a, xcb_timestamp_t b) const
+    { return static_cast<int32_t>(a - b) > 0 || b == XCB_CURRENT_TIME; }
+
+    void xi2SetupDevice(void *info, bool removeExisting = true);
+    void xi2SetupDevices();
+    struct TouchDeviceData {
+        QTouchDevice *qtTouchDevice = nullptr;
+        QHash<int, QWindowSystemInterface::TouchPoint> touchPoints;
+        QHash<int, QPointF> pointPressedPosition; // in screen coordinates where each point was pressed
+        struct ValuatorClassInfo {
+            double min = 0;
+            double max = 0;
+            int number = -1;
+            QXcbAtom::Atom label;
+        };
+        QVector<ValuatorClassInfo> valuatorInfo;
+
+        // Stuff that is relevant only for touchpads
+        QPointF firstPressedPosition;        // in screen coordinates where the first point was pressed
+        QPointF firstPressedNormalPosition;  // device coordinates (0 to 1, 0 to 1) where the first point was pressed
+        QSizeF size;                         // device size in mm
+        bool providesTouchOrientation = false;
+    };
+    TouchDeviceData *populateTouchDevices(void *info);
+    TouchDeviceData *touchDeviceForId(int id);
+    void xi2HandleEvent(xcb_ge_event_t *event);
+    void xi2HandleHierarchyEvent(void *event);
+    void xi2HandleDeviceChangedEvent(void *event);
+    void xi2ProcessTouch(void *xiDevEvent, QXcbWindow *platformWindow);
+#if QT_CONFIG(tabletevent)
+    struct TabletData {
+        int deviceId = 0;
+        QTabletEvent::PointerType pointerType = QTabletEvent::UnknownPointer;
+        QTabletEvent::TabletDevice tool = QTabletEvent::Stylus;
+        Qt::MouseButtons buttons;
+        qint64 serialId = 0;
+        bool inProximity = false;
+        struct ValuatorClassInfo {
+            double minVal = 0;
+            double maxVal = 0;
+            double curVal = 0;
+            int number = -1;
+        };
+        QHash<int, ValuatorClassInfo> valuatorInfo;
+    };
+    friend class QTypeInfo<TabletData>;
+    friend class QTypeInfo<TabletData::ValuatorClassInfo>;
+    bool xi2HandleTabletEvent(const void *event, TabletData *tabletData);
+    void xi2ReportTabletEvent(const void *event, TabletData *tabletData);
+    QVector<TabletData> m_tabletData;
+    TabletData *tabletDataForDevice(int id);
+#endif // QT_CONFIG(tabletevent)
+    struct ScrollingDevice {
+        int deviceId = 0;
+        int verticalIndex = 0;
+        int horizontalIndex = 0;
+        double verticalIncrement = 0;
+        double horizontalIncrement = 0;
+        Qt::Orientations orientations;
+        Qt::Orientations legacyOrientations;
+        QPointF lastScrollPosition;
+    };
+    QHash<int, ScrollingDevice> m_scrollingDevices;
+    void xi2HandleScrollEvent(void *event, ScrollingDevice &scrollingDevice);
+    void xi2UpdateScrollingDevice(ScrollingDevice &scrollingDevice);
+    ScrollingDevice *scrollingDeviceForId(int id);
+
+    static bool xi2GetValuatorValueIfSet(const void *event, int valuatorNum, double *value);
+
+    QHash<int, TouchDeviceData> m_touchDevices;
+    struct StartSystemMoveResizeInfo {
+        xcb_window_t window = XCB_NONE;
+        uint16_t deviceid;
+        uint32_t pointid;
+        int edges;
+    } m_startSystemMoveResizeInfo;
+
+    const bool m_canGrabServer;
+    const xcb_visualid_t m_defaultVisualId;
+
+    QList<QXcbVirtualDesktop *> m_virtualDesktops;
+    QList<QXcbScreen *> m_screens;
+
+    xcb_timestamp_t m_time = XCB_CURRENT_TIME;
+    xcb_timestamp_t m_netWmUserTime = XCB_CURRENT_TIME;
+
+    QXcbKeyboard *m_keyboard = nullptr;
+#ifndef QT_NO_CLIPBOARD
+    QXcbClipboard *m_clipboard = nullptr;
+#endif
+#if QT_CONFIG(draganddrop)
+    QXcbDrag *m_drag = nullptr;
+#endif
+    QScopedPointer<QXcbWMSupport> m_wmSupport;
+    QXcbNativeInterface *m_nativeInterface = nullptr;
+
+    QXcbEventQueue *m_eventQueue = nullptr;
+
+    WindowMapper m_mapper;
+
+    Qt::MouseButtons m_buttonState;
+    Qt::MouseButton m_button = Qt::NoButton;
+
+    QXcbWindow *m_focusWindow = nullptr;
+    QXcbWindow *m_mouseGrabber = nullptr;
+    QXcbWindow *m_mousePressWindow = nullptr;
+
+    xcb_window_t m_clientLeader = 0;
+    QByteArray m_startupId;
+    QXcbSystemTrayTracker *m_systemTrayTracker = nullptr;
+    mutable QXcbGlIntegration *m_glIntegration = nullptr;
+    mutable bool m_glIntegrationInitialized = false;
+    bool m_xiGrab = false;
+    QVector<int> m_xiMasterPointerIds;
+
+    xcb_window_t m_qtSelectionOwner = 0;
+
+    friend class QXcbEventQueue;
+
+    QByteArray m_xdgCurrentDesktop;
+    QTimer m_focusInTimer;
+
+};
+#if QT_CONFIG(tabletevent)
+Q_DECLARE_TYPEINFO(QXcbConnection::TabletData::ValuatorClassInfo, Q_PRIMITIVE_TYPE);
+Q_DECLARE_TYPEINFO(QXcbConnection::TabletData, Q_MOVABLE_TYPE);
+#endif
+
+class QXcbConnectionGrabber
+{
+public:
+    QXcbConnectionGrabber(QXcbConnection *connection);
+    ~QXcbConnectionGrabber();
+    void release();
+private:
+    QXcbConnection *m_connection;
+};
+
+// The xcb_send_event() requires all events to have 32 bytes. It calls memcpy() on the
+// passed in event. If the passed in event is less than 32 bytes, memcpy() reaches into
+// unrelated memory.
+template <typename T>
+struct alignas(32) q_padded_xcb_event : T { };
+
+QT_END_NAMESPACE
+
+#endif

--- a/xcb/libqt5xcbqpa-dev/5.15.4/qxcbconnection_basic.h
+++ b/xcb/libqt5xcbqpa-dev/5.15.4/qxcbconnection_basic.h
@@ -1,0 +1,175 @@
+/****************************************************************************
+**
+** Copyright (C) 2018 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of the QtCore module of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 2.0 or (at your option) the GNU General
+** Public license version 3 or any later version approved by the KDE Free
+** Qt Foundation. The licenses are as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
+** included in the packaging of this file. Please review the following
+** information to ensure the GNU General Public License requirements will
+** be met: https://www.gnu.org/licenses/gpl-2.0.html and
+** https://www.gnu.org/licenses/gpl-3.0.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+#ifndef QXCBBASICCONNECTION_H
+#define QXCBBASICCONNECTION_H
+
+#include "qxcbatom.h"
+#include "qxcbexport.h"
+
+#include <QtCore/QPair>
+#include <QtCore/QObject>
+#include <QtCore/QByteArray>
+#include <QtCore/QLoggingCategory>
+#include <QtGui/private/qtguiglobal_p.h>
+
+#include <xcb/xcb.h>
+
+#include <memory>
+
+QT_BEGIN_NAMESPACE
+
+Q_DECLARE_LOGGING_CATEGORY(lcQpaXcb)
+
+class Q_XCB_EXPORT QXcbBasicConnection : public QObject
+{
+    Q_OBJECT
+public:
+    QXcbBasicConnection(const char *displayName);
+    ~QXcbBasicConnection();
+
+#if QT_CONFIG(xcb_xlib)
+    void *xlib_display() const { return m_xlibDisplay; }
+#endif
+    const char *displayName() const { return m_displayName.constData(); }
+    int primaryScreenNumber() const { return m_primaryScreenNumber; }
+    xcb_connection_t *xcb_connection() const { return m_xcbConnection; }
+    bool isConnected() const {
+        return m_xcbConnection && !xcb_connection_has_error(m_xcbConnection);
+    }
+    const xcb_setup_t *setup() const { return m_setup; }
+
+    size_t maxRequestDataBytes(size_t requestSize) const;
+
+    inline xcb_atom_t atom(QXcbAtom::Atom qatom) const { return m_xcbAtom.atom(qatom); }
+    QXcbAtom::Atom qatom(xcb_atom_t atom) const { return m_xcbAtom.qatom(atom); }
+    xcb_atom_t internAtom(const char *name);
+    QByteArray atomName(xcb_atom_t atom);
+
+    bool hasXFixes() const { return m_hasXFixes; }
+    bool hasXShape() const { return m_hasXhape; }
+    bool hasXRandr() const { return m_hasXRandr; }
+    bool hasInputShape() const { return m_hasInputShape; }
+    bool hasXKB() const { return m_hasXkb; }
+    bool hasXRender(int major = -1, int minor = -1) const {
+        if (m_hasXRender && major != -1 && minor != -1)
+            return m_xrenderVersion >= qMakePair(major, minor);
+
+        return m_hasXRender;
+    }
+    bool hasXInput2() const { return m_xi2Enabled; }
+    bool hasShm() const { return m_hasShm; }
+    bool hasShmFd() const { return m_hasShmFd; }
+    bool hasXSync() const { return m_hasXSync; }
+    bool hasXinerama() const { return m_hasXinerama; }
+    bool hasBigRequest() const;
+
+    bool isAtLeastXI21() const { return m_xi2Enabled && m_xi2Minor >= 1; }
+    bool isAtLeastXI22() const { return m_xi2Enabled && m_xi2Minor >= 2; }
+    bool isXIEvent(xcb_generic_event_t *event) const;
+    bool isXIType(xcb_generic_event_t *event, uint16_t type) const;
+
+    bool isXFixesType(uint responseType, int eventType) const;
+    bool isXRandrType(uint responseType, int eventType) const;
+    bool isXkbType(uint responseType) const; // https://bugs.freedesktop.org/show_bug.cgi?id=51295
+
+protected:
+    void initializeShm();
+    void initializeXFixes();
+    void initializeXRender();
+    void initializeXRandr();
+    void initializeXinerama();
+    void initializeXShape();
+    void initializeXKB();
+    void initializeXSync();
+    void initializeXInput2();
+
+private:
+#if QT_CONFIG(xcb_xlib)
+    void *m_xlibDisplay = nullptr;
+#endif
+    QByteArray m_displayName;
+    xcb_connection_t *m_xcbConnection = nullptr;
+    int m_primaryScreenNumber = 0;
+    const xcb_setup_t *m_setup = nullptr;
+    QXcbAtom m_xcbAtom;
+
+    bool m_hasXFixes = false;
+    bool m_hasXinerama = false;
+    bool m_hasXhape = false;
+    bool m_hasInputShape;
+    bool m_hasXRandr = false;
+    bool m_hasXkb = false;
+    bool m_hasXRender = false;
+    bool m_hasShm = false;
+    bool m_hasShmFd = false;
+    bool m_hasXSync = false;
+
+    QPair<int, int> m_xrenderVersion;
+
+    bool m_xi2Enabled = false;
+    int m_xi2Minor = -1;
+    int m_xiOpCode = -1;
+    uint32_t m_xinputFirstEvent = 0;
+
+    uint32_t m_xfixesFirstEvent = 0;
+    uint32_t m_xrandrFirstEvent = 0;
+    uint32_t m_xkbFirstEvent = 0;
+
+    uint32_t m_maximumRequestLength = 0;
+};
+
+#define Q_XCB_REPLY_CONNECTION_ARG(connection, ...) connection
+
+struct QStdFreeDeleter {
+    void operator()(void *p) const noexcept { return std::free(p); }
+};
+
+#define Q_XCB_REPLY(call, ...) \
+    std::unique_ptr<call##_reply_t, QStdFreeDeleter>( \
+        call##_reply(Q_XCB_REPLY_CONNECTION_ARG(__VA_ARGS__), call(__VA_ARGS__), nullptr) \
+    )
+
+#define Q_XCB_REPLY_UNCHECKED(call, ...) \
+    std::unique_ptr<call##_reply_t, QStdFreeDeleter>( \
+        call##_reply(Q_XCB_REPLY_CONNECTION_ARG(__VA_ARGS__), call##_unchecked(__VA_ARGS__), nullptr) \
+    )
+
+QT_END_NAMESPACE
+
+#endif // QXCBBASICCONNECTION_H

--- a/xcb/libqt5xcbqpa-dev/5.15.4/qxcbcursor.h
+++ b/xcb/libqt5xcbqpa-dev/5.15.4/qxcbcursor.h
@@ -1,0 +1,129 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of the plugins of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 2.0 or (at your option) the GNU General
+** Public license version 3 or any later version approved by the KDE Free
+** Qt Foundation. The licenses are as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
+** included in the packaging of this file. Please review the following
+** information to ensure the GNU General Public License requirements will
+** be met: https://www.gnu.org/licenses/gpl-2.0.html and
+** https://www.gnu.org/licenses/gpl-3.0.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef QXCBCURSOR_H
+#define QXCBCURSOR_H
+
+#include <qpa/qplatformcursor.h>
+#include "qxcbscreen.h"
+
+#include <QtCore/QCache>
+
+QT_BEGIN_NAMESPACE
+
+#ifndef QT_NO_CURSOR
+
+struct QXcbCursorCacheKey
+{
+    explicit QXcbCursorCacheKey(const QCursor &c);
+    explicit QXcbCursorCacheKey(Qt::CursorShape s) : shape(s), bitmapCacheKey(0), maskCacheKey(0) {}
+    QXcbCursorCacheKey() : shape(Qt::CustomCursor), bitmapCacheKey(0), maskCacheKey(0) {}
+
+    Qt::CursorShape shape;
+    qint64 bitmapCacheKey;
+    qint64 maskCacheKey;
+};
+
+inline bool operator==(const QXcbCursorCacheKey &k1, const QXcbCursorCacheKey &k2)
+{
+    return k1.shape == k2.shape && k1.bitmapCacheKey == k2.bitmapCacheKey && k1.maskCacheKey == k2.maskCacheKey;
+}
+
+inline uint qHash(const QXcbCursorCacheKey &k, uint seed) noexcept
+{
+    return (uint(k.shape) + uint(k.bitmapCacheKey) + uint(k.maskCacheKey)) ^ seed;
+}
+
+#endif // !QT_NO_CURSOR
+
+class QXcbCursor : public QXcbObject, public QPlatformCursor
+{
+public:
+    QXcbCursor(QXcbConnection *conn, QXcbScreen *screen);
+    ~QXcbCursor();
+#ifndef QT_NO_CURSOR
+    void changeCursor(QCursor *cursor, QWindow *window) override;
+#endif
+    QPoint pos() const override;
+    void setPos(const QPoint &pos) override;
+
+    static void queryPointer(QXcbConnection *c, QXcbVirtualDesktop **virtualDesktop, QPoint *pos, int *keybMask = nullptr);
+
+#ifndef QT_NO_CURSOR
+    xcb_cursor_t xcbCursor(const QCursor &c) const
+        { return m_cursorHash.value(QXcbCursorCacheKey(c), xcb_cursor_t(0)); }
+#endif
+
+private:
+
+#ifndef QT_NO_CURSOR
+    typedef QHash<QXcbCursorCacheKey, xcb_cursor_t> CursorHash;
+
+    struct CachedCursor
+    {
+        explicit CachedCursor(xcb_connection_t *conn, xcb_cursor_t c)
+            : cursor(c), connection(conn) {}
+        ~CachedCursor() { xcb_free_cursor(connection, cursor); }
+        xcb_cursor_t cursor;
+        xcb_connection_t *connection;
+    };
+    typedef QCache<QXcbCursorCacheKey, CachedCursor> BitmapCursorCache;
+
+    xcb_cursor_t createFontCursor(int cshape);
+    xcb_cursor_t createBitmapCursor(QCursor *cursor);
+    xcb_cursor_t createNonStandardCursor(int cshape);
+#endif
+
+    QXcbScreen *m_screen;
+#ifndef QT_NO_CURSOR
+    CursorHash m_cursorHash;
+    BitmapCursorCache m_bitmapCache;
+#endif
+#if QT_CONFIG(xcb_xlib) && QT_CONFIG(library)
+    static void cursorThemePropertyChanged(QXcbVirtualDesktop *screen,
+                                           const QByteArray &name,
+                                           const QVariant &property,
+                                           void *handle);
+#endif
+    bool m_gtkCursorThemeInitialized;
+};
+
+QT_END_NAMESPACE
+
+#endif

--- a/xcb/libqt5xcbqpa-dev/5.15.4/qxcbdrag.h
+++ b/xcb/libqt5xcbqpa-dev/5.15.4/qxcbdrag.h
@@ -1,0 +1,198 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of the QtGui module of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 2.0 or (at your option) the GNU General
+** Public license version 3 or any later version approved by the KDE Free
+** Qt Foundation. The licenses are as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
+** included in the packaging of this file. Please review the following
+** information to ensure the GNU General Public License requirements will
+** be met: https://www.gnu.org/licenses/gpl-2.0.html and
+** https://www.gnu.org/licenses/gpl-3.0.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef QXCBDRAG_H
+#define QXCBDRAG_H
+
+#include <qpa/qplatformdrag.h>
+#include <private/qsimpledrag_p.h>
+#include <qxcbobject.h>
+#include <xcb/xcb.h>
+#include <qpoint.h>
+#include <qrect.h>
+#include <qsharedpointer.h>
+#include <qpointer.h>
+#include <qvector.h>
+#include <qdatetime.h>
+#include <qpixmap.h>
+#include <qbackingstore.h>
+
+#include <QtCore/QDebug>
+
+QT_REQUIRE_CONFIG(draganddrop);
+
+QT_BEGIN_NAMESPACE
+
+class QWindow;
+class QPlatformWindow;
+class QXcbConnection;
+class QXcbWindow;
+class QXcbDropData;
+class QXcbScreen;
+class QDrag;
+class QShapedPixmapWindow;
+
+class QXcbDrag : public QXcbObject, public QBasicDrag, public QXcbWindowEventListener
+{
+public:
+    QXcbDrag(QXcbConnection *c);
+    ~QXcbDrag();
+
+    bool eventFilter(QObject *o, QEvent *e) override;
+
+    void startDrag() override;
+    void cancel() override;
+    void move(const QPoint &globalPos, Qt::MouseButtons b, Qt::KeyboardModifiers mods) override;
+    void drop(const QPoint &globalPos, Qt::MouseButtons b, Qt::KeyboardModifiers mods) override;
+    void endDrag() override;
+
+    Qt::DropAction defaultAction(Qt::DropActions possibleActions, Qt::KeyboardModifiers modifiers) const override;
+
+    void handlePropertyNotifyEvent(const xcb_property_notify_event_t *event) override;
+
+    void handleEnter(QPlatformWindow *window, const xcb_client_message_event_t *event, xcb_window_t proxy = 0);
+    void handlePosition(QPlatformWindow *w, const xcb_client_message_event_t *event);
+    void handleLeave(QPlatformWindow *w, const xcb_client_message_event_t *event);
+    void handleDrop(QPlatformWindow *, const xcb_client_message_event_t *event,
+                    Qt::MouseButtons b = { }, Qt::KeyboardModifiers mods = { });
+
+    void handleStatus(const xcb_client_message_event_t *event);
+    void handleSelectionRequest(const xcb_selection_request_event_t *event);
+    void handleFinished(const xcb_client_message_event_t *event);
+
+    bool dndEnable(QXcbWindow *win, bool on);
+    bool ownsDragObject() const override;
+
+    void updatePixmap();
+    xcb_timestamp_t targetTime() { return target_time; }
+
+protected:
+    void timerEvent(QTimerEvent* e) override;
+
+    bool findXdndAwareTarget(const QPoint &globalPos, xcb_window_t *target_out);
+
+private:
+    friend class QXcbDropData;
+
+    void init();
+
+    void handle_xdnd_position(QPlatformWindow *w, const xcb_client_message_event_t *event,
+                              Qt::MouseButtons b = { }, Qt::KeyboardModifiers mods = { });
+    void handle_xdnd_status(const xcb_client_message_event_t *event);
+    void send_leave();
+
+    Qt::DropAction toDropAction(xcb_atom_t atom) const;
+    Qt::DropActions toDropActions(const QVector<xcb_atom_t> &atoms) const;
+    xcb_atom_t toXdndAction(Qt::DropAction a) const;
+
+    void readActionList();
+    void setActionList(Qt::DropAction requestedAction, Qt::DropActions supportedActions);
+    void startListeningForActionListChanges();
+    void stopListeningForActionListChanges();
+
+    QPointer<QWindow> initiatorWindow;
+    QPointer<QWindow> currentWindow;
+    QPoint currentPosition;
+
+    QXcbDropData *m_dropData;
+    Qt::DropAction accepted_drop_action;
+
+    QWindow *desktop_proxy;
+
+    xcb_atom_t xdnd_dragsource;
+
+    // the types in this drop. 100 is no good, but at least it's big.
+    enum { xdnd_max_type = 100 };
+    QVector<xcb_atom_t> xdnd_types;
+
+    // timestamp from XdndPosition and XdndDroptime for retrieving the data
+    xcb_timestamp_t target_time;
+    xcb_timestamp_t source_time;
+
+    // rectangle in which the answer will be the same
+    QRect source_sameanswer;
+    bool waiting_for_status;
+
+    // helpers for setting executed drop action outside application
+    bool dropped;
+    bool canceled;
+
+    // A window from Unity DnD Manager, which does not respect the XDnD spec
+    xcb_window_t xdndCollectionWindow = XCB_NONE;
+
+    // top-level window we sent position to last.
+    xcb_window_t current_target;
+    // window to send events to (always valid if current_target)
+    xcb_window_t current_proxy_target;
+
+    QXcbVirtualDesktop *current_virtual_desktop;
+
+    // 10 minute timer used to discard old XdndDrop transactions
+    enum { XdndDropTransactionTimeout = 600000 };
+    int cleanup_timer;
+
+    QVector<xcb_atom_t> drag_types;
+
+    QVector<xcb_atom_t> current_actions;
+    QVector<xcb_atom_t> drop_actions;
+
+    struct Transaction
+    {
+        xcb_timestamp_t timestamp;
+        xcb_window_t target;
+        xcb_window_t proxy_target;
+        QPlatformWindow *targetWindow;
+//        QWidget *embedding_widget;
+        QPointer<QDrag> drag;
+        QTime time;
+    };
+    friend class QTypeInfo<Transaction>;
+    QVector<Transaction> transactions;
+
+    int transaction_expiry_timer;
+    void restartDropExpiryTimer();
+    int findTransactionByWindow(xcb_window_t window);
+    int findTransactionByTime(xcb_timestamp_t timestamp);
+    xcb_window_t findRealWindow(const QPoint & pos, xcb_window_t w, int md, bool ignoreNonXdndAwareWindows);
+};
+Q_DECLARE_TYPEINFO(QXcbDrag::Transaction, Q_MOVABLE_TYPE);
+
+QT_END_NAMESPACE
+
+#endif

--- a/xcb/libqt5xcbqpa-dev/5.15.4/qxcbeventdispatcher.h
+++ b/xcb/libqt5xcbqpa-dev/5.15.4/qxcbeventdispatcher.h
@@ -1,0 +1,114 @@
+/****************************************************************************
+**
+** Copyright (C) 2018 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of the QtCore module of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 2.0 or (at your option) the GNU General
+** Public license version 3 or any later version approved by the KDE Free
+** Qt Foundation. The licenses are as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
+** included in the packaging of this file. Please review the following
+** information to ensure the GNU General Public License requirements will
+** be met: https://www.gnu.org/licenses/gpl-2.0.html and
+** https://www.gnu.org/licenses/gpl-3.0.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+#ifndef QXCBEVENTDISPATCHER_H
+#define QXCBEVENTDISPATCHER_H
+
+#include <QtCore/QObject>
+#include <QtCore/QEventLoop>
+
+#include <QtCore/private/qeventdispatcher_unix_p.h>
+#if QT_CONFIG(glib)
+#include <QtCore/private/qeventdispatcher_glib_p.h>
+#include <glib.h>
+#endif
+
+QT_BEGIN_NAMESPACE
+
+class QXcbConnection;
+
+class QXcbUnixEventDispatcher : public QEventDispatcherUNIX
+{
+    Q_OBJECT
+public:
+    explicit QXcbUnixEventDispatcher(QXcbConnection *connection, QObject *parent = nullptr);
+    ~QXcbUnixEventDispatcher();
+    bool processEvents(QEventLoop::ProcessEventsFlags flags) override;
+
+    // Maybe some user code depends on deprecated QUnixEventDispatcherQPA::
+    // hasPendingEvents() / flush() implementation, so keep it around until
+    // Qt 6. These methods are deprecated in QAbstractEventDispatcher.
+    bool hasPendingEvents() override; // ### Qt 6 remove
+    void flush() override;            // ### Qt 6 remove
+
+private:
+    QXcbConnection *m_connection;
+};
+
+#if QT_CONFIG(glib)
+
+struct XcbEventSource;
+class QXcbGlibEventDispatcherPrivate;
+
+class QXcbGlibEventDispatcher : public QEventDispatcherGlib
+{
+    Q_OBJECT
+    Q_DECLARE_PRIVATE(QXcbGlibEventDispatcher)
+
+public:
+    explicit QXcbGlibEventDispatcher(QXcbConnection *connection, QObject *parent = nullptr);
+    ~QXcbGlibEventDispatcher();
+
+    bool processEvents(QEventLoop::ProcessEventsFlags flags) override;
+    QEventLoop::ProcessEventsFlags flags() const { return m_flags; }
+
+private:
+    XcbEventSource *m_xcbEventSource;
+    GSourceFuncs m_xcbEventSourceFuncs;
+    QEventLoop::ProcessEventsFlags m_flags;
+};
+
+class QXcbGlibEventDispatcherPrivate : public QEventDispatcherGlibPrivate
+{
+    Q_DECLARE_PUBLIC(QXcbGlibEventDispatcher)
+
+public:
+    QXcbGlibEventDispatcherPrivate();
+};
+
+#endif // QT_CONFIG(glib)
+
+class QXcbEventDispatcher
+{
+public:
+    static QAbstractEventDispatcher *createEventDispatcher(QXcbConnection *connection);
+};
+
+QT_END_NAMESPACE
+
+#endif // QXCBEVENTDISPATCHER_H

--- a/xcb/libqt5xcbqpa-dev/5.15.4/qxcbeventqueue.h
+++ b/xcb/libqt5xcbqpa-dev/5.15.4/qxcbeventqueue.h
@@ -1,0 +1,170 @@
+/****************************************************************************
+**
+** Copyright (C) 2018 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of the QtCore module of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 2.0 or (at your option) the GNU General
+** Public license version 3 or any later version approved by the KDE Free
+** Qt Foundation. The licenses are as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
+** included in the packaging of this file. Please review the following
+** information to ensure the GNU General Public License requirements will
+** be met: https://www.gnu.org/licenses/gpl-2.0.html and
+** https://www.gnu.org/licenses/gpl-3.0.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+#ifndef QXCBEVENTQUEUE_H
+#define QXCBEVENTQUEUE_H
+
+#include <QtCore/QThread>
+#include <QtCore/QHash>
+#include <QtCore/QEventLoop>
+#include <QtCore/QVector>
+#include <QtCore/QMutex>
+#include <QtCore/QWaitCondition>
+
+#include <xcb/xcb.h>
+
+#include <atomic>
+
+QT_BEGIN_NAMESPACE
+
+struct QXcbEventNode {
+    QXcbEventNode(xcb_generic_event_t *e = nullptr)
+        : event(e) { }
+
+    xcb_generic_event_t *event;
+    QXcbEventNode *next = nullptr;
+    bool fromHeap = false;
+};
+
+class QXcbConnection;
+class QAbstractEventDispatcher;
+
+class QXcbEventQueue : public QThread
+{
+    Q_OBJECT
+public:
+    QXcbEventQueue(QXcbConnection *connection);
+    ~QXcbEventQueue();
+
+    enum { PoolSize = 100 }; // 2.4 kB with 100 nodes
+
+    enum PeekOption {
+        PeekDefault = 0, // see qx11info_x11.h for docs
+        PeekFromCachedIndex = 1,
+        PeekRetainMatch = 2,
+        PeekRemoveMatch = 3,
+        PeekRemoveMatchContinue = 4
+    };
+    Q_DECLARE_FLAGS(PeekOptions, PeekOption)
+
+    void run() override;
+
+    bool isEmpty() const { return m_head == m_flushedTail && !m_head->event; }
+    xcb_generic_event_t *takeFirst(QEventLoop::ProcessEventsFlags flags);
+    xcb_generic_event_t *takeFirst();
+    void flushBufferedEvents();
+    void wakeUpDispatcher();
+
+    // ### peek() and peekEventQueue() could be unified. Note that peekEventQueue()
+    // is public API exposed via QX11Extras/QX11Info.
+    template<typename Peeker>
+    xcb_generic_event_t *peek(Peeker &&peeker) {
+        return peek(PeekRemoveMatch, std::forward<Peeker>(peeker));
+    }
+    template<typename Peeker>
+    inline xcb_generic_event_t *peek(PeekOption config, Peeker &&peeker);
+
+    qint32 generatePeekerId();
+    bool removePeekerId(qint32 peekerId);
+
+    using PeekerCallback = bool (*)(xcb_generic_event_t *event, void *peekerData);
+    bool peekEventQueue(PeekerCallback peeker, void *peekerData = nullptr,
+                        PeekOptions option = PeekDefault, qint32 peekerId = -1);
+
+    const QXcbEventNode *flushedTail() const { return m_flushedTail; }
+    void waitForNewEvents(const QXcbEventNode *sinceFlushedTail, unsigned long time = ULONG_MAX);
+
+private:
+    QXcbEventNode *qXcbEventNodeFactory(xcb_generic_event_t *event);
+    void dequeueNode();
+
+    void sendCloseConnectionEvent() const;
+    bool isCloseConnectionEvent(const xcb_generic_event_t *event);
+
+    QXcbEventNode *m_head = nullptr;
+    QXcbEventNode *m_flushedTail = nullptr;
+    std::atomic<QXcbEventNode *> m_tail { nullptr };
+    std::atomic_uint m_nodesRestored { 0 };
+
+    QXcbConnection *m_connection = nullptr;
+    bool m_closeConnectionDetected = false;
+
+    uint m_freeNodes = PoolSize;
+    uint m_poolIndex = 0;
+
+    qint32 m_peekerIdSource = 0;
+    bool m_queueModified = false;
+    bool m_peekerIndexCacheDirty = false;
+    QHash<qint32, QXcbEventNode *> m_peekerToNode;
+
+    QVector<xcb_generic_event_t *> m_inputEvents;
+
+    // debug stats
+    quint64 m_nodesOnHeap = 0;
+
+    QMutex m_newEventsMutex;
+    QWaitCondition m_newEventsCondition;
+};
+
+template<typename Peeker>
+xcb_generic_event_t *QXcbEventQueue::peek(PeekOption option, Peeker &&peeker)
+{
+    flushBufferedEvents();
+    if (isEmpty())
+        return nullptr;
+
+    QXcbEventNode *node = m_head;
+    do {
+        xcb_generic_event_t *event = node->event;
+        if (event && peeker(event, event->response_type & ~0x80)) {
+            if (option == PeekRemoveMatch || option == PeekRemoveMatchContinue)
+                node->event = nullptr;
+            if (option != PeekRemoveMatchContinue)
+                return event;
+        }
+        if (node == m_flushedTail)
+            break;
+        node = node->next;
+    } while (true);
+
+    return nullptr;
+}
+
+QT_END_NAMESPACE
+
+#endif

--- a/xcb/libqt5xcbqpa-dev/5.15.4/qxcbexport.h
+++ b/xcb/libqt5xcbqpa-dev/5.15.4/qxcbexport.h
@@ -1,0 +1,55 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of the plugins of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 2.0 or (at your option) the GNU General
+** Public license version 3 or any later version approved by the KDE Free
+** Qt Foundation. The licenses are as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
+** included in the packaging of this file. Please review the following
+** information to ensure the GNU General Public License requirements will
+** be met: https://www.gnu.org/licenses/gpl-2.0.html and
+** https://www.gnu.org/licenses/gpl-3.0.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef QXCBEXPORT_H
+#define QXCBEXPORT_H
+
+#include <QtCore/qglobal.h>
+
+QT_BEGIN_NAMESPACE
+
+#  if defined(QT_BUILD_XCB_PLUGIN)
+#    define Q_XCB_EXPORT Q_DECL_EXPORT
+#  else
+#    define Q_XCB_EXPORT Q_DECL_IMPORT
+#  endif
+
+QT_END_NAMESPACE
+#endif //QXCBEXPORT_H
+

--- a/xcb/libqt5xcbqpa-dev/5.15.4/qxcbimage.h
+++ b/xcb/libqt5xcbqpa-dev/5.15.4/qxcbimage.h
@@ -1,0 +1,62 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of the plugins of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 2.0 or (at your option) the GNU General
+** Public license version 3 or any later version approved by the KDE Free
+** Qt Foundation. The licenses are as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
+** included in the packaging of this file. Please review the following
+** information to ensure the GNU General Public License requirements will
+** be met: https://www.gnu.org/licenses/gpl-2.0.html and
+** https://www.gnu.org/licenses/gpl-3.0.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef QXCBIMAGE_H
+#define QXCBIMAGE_H
+
+#include "qxcbscreen.h"
+#include <QtCore/QPair>
+#include <QtGui/QImage>
+#include <QtGui/QPixmap>
+#include <xcb/xcb_image.h>
+
+QT_BEGIN_NAMESPACE
+
+bool qt_xcb_imageFormatForVisual(QXcbConnection *connection, uint8_t depth, const xcb_visualtype_t *visual,
+                                 QImage::Format *imageFormat, bool *needsRgbSwap = nullptr);
+QPixmap qt_xcb_pixmapFromXPixmap(QXcbConnection *connection, xcb_pixmap_t pixmap,
+                                 int width, int height, int depth,
+                                 const xcb_visualtype_t *visual);
+xcb_pixmap_t qt_xcb_XPixmapFromBitmap(QXcbScreen *screen, const QImage &image);
+xcb_cursor_t qt_xcb_createCursorXRender(QXcbScreen *screen, const QImage &image,
+                                        const QPoint &spot);
+
+QT_END_NAMESPACE
+
+#endif

--- a/xcb/libqt5xcbqpa-dev/5.15.4/qxcbintegration.h
+++ b/xcb/libqt5xcbqpa-dev/5.15.4/qxcbintegration.h
@@ -1,0 +1,150 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of the plugins of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 2.0 or (at your option) the GNU General
+** Public license version 3 or any later version approved by the KDE Free
+** Qt Foundation. The licenses are as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
+** included in the packaging of this file. Please review the following
+** information to ensure the GNU General Public License requirements will
+** be met: https://www.gnu.org/licenses/gpl-2.0.html and
+** https://www.gnu.org/licenses/gpl-3.0.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef QXCBINTEGRATION_H
+#define QXCBINTEGRATION_H
+
+#include <QtGui/private/qtguiglobal_p.h>
+#include <qpa/qplatformintegration.h>
+#include <qpa/qplatformscreen.h>
+
+#include "qxcbexport.h"
+
+#include <xcb/xcb.h>
+
+QT_BEGIN_NAMESPACE
+
+class QXcbConnection;
+class QAbstractEventDispatcher;
+class QXcbNativeInterface;
+
+class Q_XCB_EXPORT QXcbIntegration : public QPlatformIntegration
+{
+public:
+    QXcbIntegration(const QStringList &parameters, int &argc, char **argv);
+    ~QXcbIntegration();
+
+    QPlatformPixmap *createPlatformPixmap(QPlatformPixmap::PixelType type) const override;
+    QPlatformWindow *createPlatformWindow(QWindow *window) const override;
+    QPlatformWindow *createForeignWindow(QWindow *window, WId nativeHandle) const override;
+#ifndef QT_NO_OPENGL
+    QPlatformOpenGLContext *createPlatformOpenGLContext(QOpenGLContext *context) const override;
+#endif
+    QPlatformBackingStore *createPlatformBackingStore(QWindow *window) const override;
+
+    QPlatformOffscreenSurface *createPlatformOffscreenSurface(QOffscreenSurface *surface) const override;
+
+    bool hasCapability(Capability cap) const override;
+    QAbstractEventDispatcher *createEventDispatcher() const override;
+    void initialize() override;
+
+    void moveToScreen(QWindow *window, int screen);
+
+    QPlatformFontDatabase *fontDatabase() const override;
+
+    QPlatformNativeInterface *nativeInterface()const override;
+
+#ifndef QT_NO_CLIPBOARD
+    QPlatformClipboard *clipboard() const override;
+#endif
+#if QT_CONFIG(draganddrop)
+    QPlatformDrag *drag() const override;
+#endif
+
+    QPlatformInputContext *inputContext() const override;
+
+#ifndef QT_NO_ACCESSIBILITY
+    QPlatformAccessibility *accessibility() const override;
+#endif
+
+    QPlatformServices *services() const override;
+
+    Qt::KeyboardModifiers queryKeyboardModifiers() const override;
+    QList<int> possibleKeys(const QKeyEvent *e) const override;
+
+    QStringList themeNames() const override;
+    QPlatformTheme *createPlatformTheme(const QString &name) const override;
+    QVariant styleHint(StyleHint hint) const override;
+
+    bool hasDefaultConnection() const { return !m_connections.isEmpty(); }
+    QXcbConnection *defaultConnection() const { return m_connections.first(); }
+
+    QByteArray wmClass() const;
+
+#if QT_CONFIG(xcb_sm)
+    QPlatformSessionManager *createPlatformSessionManager(const QString &id, const QString &key) const override;
+#endif
+
+    void sync() override;
+
+    void beep() const override;
+
+    bool nativePaintingEnabled() const;
+
+#if QT_CONFIG(vulkan)
+    QPlatformVulkanInstance *createPlatformVulkanInstance(QVulkanInstance *instance) const override;
+#endif
+
+    static QXcbIntegration *instance() { return m_instance; }
+
+private:
+    QList<QXcbConnection *> m_connections;
+
+    QScopedPointer<QPlatformFontDatabase> m_fontDatabase;
+    QScopedPointer<QXcbNativeInterface> m_nativeInterface;
+
+    QScopedPointer<QPlatformInputContext> m_inputContext;
+
+#ifndef QT_NO_ACCESSIBILITY
+    mutable QScopedPointer<QPlatformAccessibility> m_accessibility;
+#endif
+
+    QScopedPointer<QPlatformServices> m_services;
+
+    mutable QByteArray m_wmClass;
+    const char *m_instanceName;
+    bool m_canGrab;
+    xcb_visualid_t m_defaultVisualId;
+
+    static QXcbIntegration *m_instance;
+};
+
+QT_END_NAMESPACE
+
+#endif

--- a/xcb/libqt5xcbqpa-dev/5.15.4/qxcbkeyboard.h
+++ b/xcb/libqt5xcbqpa-dev/5.15.4/qxcbkeyboard.h
@@ -1,0 +1,141 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of the plugins of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 2.0 or (at your option) the GNU General
+** Public license version 3 or any later version approved by the KDE Free
+** Qt Foundation. The licenses are as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
+** included in the packaging of this file. Please review the following
+** information to ensure the GNU General Public License requirements will
+** be met: https://www.gnu.org/licenses/gpl-2.0.html and
+** https://www.gnu.org/licenses/gpl-3.0.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef QXCBKEYBOARD_H
+#define QXCBKEYBOARD_H
+
+#include "qxcbobject.h"
+
+#include <xcb/xcb_keysyms.h>
+#define explicit dont_use_cxx_explicit
+#include <xcb/xkb.h>
+#undef explicit
+
+#include <QtXkbCommonSupport/private/qxkbcommon_p.h>
+#include <xkbcommon/xkbcommon-x11.h>
+
+#include <QEvent>
+
+QT_BEGIN_NAMESPACE
+
+class QXcbKeyboard : public QXcbObject
+{
+public:
+    QXcbKeyboard(QXcbConnection *connection);
+
+    ~QXcbKeyboard();
+
+    void initialize();
+    void selectEvents();
+
+    void handleKeyPressEvent(const xcb_key_press_event_t *event);
+    void handleKeyReleaseEvent(const xcb_key_release_event_t *event);
+
+    Qt::KeyboardModifiers translateModifiers(int s) const;
+    void updateKeymap(xcb_mapping_notify_event_t *event);
+    void updateKeymap();
+    QList<int> possibleKeys(const QKeyEvent *event) const;
+
+    void updateXKBMods();
+    xkb_mod_mask_t xkbModMask(quint16 state);
+    void updateXKBStateFromCore(quint16 state);
+    void updateXKBStateFromXI(void *modInfo, void *groupInfo);
+
+    int coreDeviceId() const { return core_device_id; }
+    void updateXKBState(xcb_xkb_state_notify_event_t *state);
+
+    void handleStateChanges(xkb_state_component changedComponents);
+
+protected:
+    void handleKeyEvent(xcb_window_t sourceWindow, QEvent::Type type, xcb_keycode_t code,
+                        quint16 state, xcb_timestamp_t time, bool fromSendEvent);
+
+    void resolveMaskConflicts();
+
+    typedef QMap<xcb_keysym_t, int> KeysymModifierMap;
+    struct xkb_keymap *keymapFromCore(const KeysymModifierMap &keysymMods);
+
+    void updateModifiers(const KeysymModifierMap &keysymMods);
+    KeysymModifierMap keysymsToModifiers();
+
+    void updateVModMapping();
+    void updateVModToRModMapping();
+
+private:
+    bool m_config = false;
+    bool m_isAutoRepeat = false;
+    xcb_keycode_t m_autoRepeatCode = 0;
+
+    struct _mod_masks {
+        uint alt;
+        uint altgr;
+        uint meta;
+        uint super;
+        uint hyper;
+    };
+
+    _mod_masks rmod_masks;
+
+    xcb_key_symbols_t *m_key_symbols = nullptr;
+    struct _xkb_mods {
+        xkb_mod_index_t shift;
+        xkb_mod_index_t lock;
+        xkb_mod_index_t control;
+        xkb_mod_index_t mod1;
+        xkb_mod_index_t mod2;
+        xkb_mod_index_t mod3;
+        xkb_mod_index_t mod4;
+        xkb_mod_index_t mod5;
+    };
+    _xkb_mods xkb_mods;
+
+    _mod_masks vmod_masks;
+    int core_device_id;
+
+    QXkbCommon::ScopedXKBState m_xkbState;
+    QXkbCommon::ScopedXKBKeymap m_xkbKeymap;
+    QXkbCommon::ScopedXKBContext m_xkbContext;
+
+    bool m_superAsMeta = false;
+    bool m_hyperAsMeta = false;
+};
+
+QT_END_NAMESPACE
+
+#endif

--- a/xcb/libqt5xcbqpa-dev/5.15.4/qxcbmime.h
+++ b/xcb/libqt5xcbqpa-dev/5.15.4/qxcbmime.h
@@ -1,0 +1,70 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of the plugins of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 2.0 or (at your option) the GNU General
+** Public license version 3 or any later version approved by the KDE Free
+** Qt Foundation. The licenses are as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
+** included in the packaging of this file. Please review the following
+** information to ensure the GNU General Public License requirements will
+** be met: https://www.gnu.org/licenses/gpl-2.0.html and
+** https://www.gnu.org/licenses/gpl-3.0.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef QXCBMIME_H
+#define QXCBMIME_H
+
+#include <QtGui/private/qinternalmimedata_p.h>
+
+#include <QtGui/QClipboard>
+
+#include "qxcbintegration.h"
+#include "qxcbconnection.h"
+
+QT_BEGIN_NAMESPACE
+
+class QXcbMime : public QInternalMimeData {
+    Q_OBJECT
+public:
+    QXcbMime();
+    ~QXcbMime();
+
+    static QVector<xcb_atom_t> mimeAtomsForFormat(QXcbConnection *connection, const QString &format);
+    static QString mimeAtomToString(QXcbConnection *connection, xcb_atom_t a);
+    static bool mimeDataForAtom(QXcbConnection *connection, xcb_atom_t a, QMimeData *mimeData, QByteArray *data,
+                                xcb_atom_t *atomFormat, int *dataFormat);
+    static QVariant mimeConvertToFormat(QXcbConnection *connection, xcb_atom_t a, const QByteArray &data, const QString &format,
+                                        QMetaType::Type requestedType, const QByteArray &encoding);
+    static xcb_atom_t mimeAtomForFormat(QXcbConnection *connection, const QString &format, QMetaType::Type requestedType,
+                                        const QVector<xcb_atom_t> &atoms, QByteArray *requestedEncoding);
+};
+
+QT_END_NAMESPACE
+
+#endif // QXCBMIME_H

--- a/xcb/libqt5xcbqpa-dev/5.15.4/qxcbnativeinterface.h
+++ b/xcb/libqt5xcbqpa-dev/5.15.4/qxcbnativeinterface.h
@@ -1,0 +1,156 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of the plugins of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 2.0 or (at your option) the GNU General
+** Public license version 3 or any later version approved by the KDE Free
+** Qt Foundation. The licenses are as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
+** included in the packaging of this file. Please review the following
+** information to ensure the GNU General Public License requirements will
+** be met: https://www.gnu.org/licenses/gpl-2.0.html and
+** https://www.gnu.org/licenses/gpl-3.0.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef QXCBNATIVEINTERFACE_H
+#define QXCBNATIVEINTERFACE_H
+
+#include <qpa/qplatformnativeinterface.h>
+#include <xcb/xcb.h>
+
+#include <QtCore/QRect>
+
+#include "qxcbexport.h"
+#include "qxcbconnection.h"
+
+QT_BEGIN_NAMESPACE
+
+class QXcbScreen;
+class QXcbNativeInterfaceHandler;
+
+class Q_XCB_EXPORT QXcbNativeInterface : public QPlatformNativeInterface
+{
+    Q_OBJECT
+public:
+    enum ResourceType {
+        Display,
+        Connection,
+        Screen,
+        AppTime,
+        AppUserTime,
+        ScreenHintStyle,
+        StartupId,
+        TrayWindow,
+        GetTimestamp,
+        X11Screen,
+        RootWindow,
+        ScreenSubpixelType,
+        ScreenAntialiasingEnabled,
+        AtspiBus,
+        CompositingEnabled,
+        VkSurface,
+        GeneratePeekerId,
+        RemovePeekerId,
+        PeekEventQueue
+    };
+
+    QXcbNativeInterface();
+
+    void *nativeResourceForIntegration(const QByteArray &resource) override;
+    void *nativeResourceForContext(const QByteArray &resourceString, QOpenGLContext *context) override;
+    void *nativeResourceForScreen(const QByteArray &resource, QScreen *screen) override;
+    void *nativeResourceForWindow(const QByteArray &resourceString, QWindow *window) override;
+    void *nativeResourceForBackingStore(const QByteArray &resource, QBackingStore *backingStore) override;
+#ifndef QT_NO_CURSOR
+    void *nativeResourceForCursor(const QByteArray &resource, const QCursor &cursor) override;
+#endif
+
+    NativeResourceForIntegrationFunction nativeResourceFunctionForIntegration(const QByteArray &resource) override;
+    NativeResourceForContextFunction nativeResourceFunctionForContext(const QByteArray &resource) override;
+    NativeResourceForScreenFunction nativeResourceFunctionForScreen(const QByteArray &resource) override;
+    NativeResourceForWindowFunction nativeResourceFunctionForWindow(const QByteArray &resource) override;
+    NativeResourceForBackingStoreFunction nativeResourceFunctionForBackingStore(const QByteArray &resource) override;
+
+    QFunctionPointer platformFunction(const QByteArray &function) const override;
+
+    inline const QByteArray &nativeEventType() const { return m_nativeEventType; }
+
+    void *displayForWindow(QWindow *window);
+    void *connectionForWindow(QWindow *window);
+    void *screenForWindow(QWindow *window);
+    void *appTime(const QXcbScreen *screen);
+    void *appUserTime(const QXcbScreen *screen);
+    void *getTimestamp(const QXcbScreen *screen);
+    void *startupId();
+    void *x11Screen();
+    void *rootWindow();
+    void *display();
+    void *atspiBus();
+    void *connection();
+    static void setStartupId(const char *);
+    static void setAppTime(QScreen *screen, xcb_timestamp_t time);
+    static void setAppUserTime(QScreen *screen, xcb_timestamp_t time);
+
+    static qint32 generatePeekerId();
+    static bool removePeekerId(qint32 peekerId);
+    static bool peekEventQueue(QXcbEventQueue::PeekerCallback peeker, void *peekerData = nullptr,
+                               QXcbEventQueue::PeekOptions option = QXcbEventQueue::PeekDefault,
+                               qint32 peekerId = -1);
+
+    Q_INVOKABLE QString dumpConnectionNativeWindows(const QXcbConnection *connection, WId root) const;
+    Q_INVOKABLE QString dumpNativeWindows(WId root = 0) const;
+
+    void addHandler(QXcbNativeInterfaceHandler *handler);
+    void removeHandler(QXcbNativeInterfaceHandler *handler);
+signals:
+    void systemTrayWindowChanged(QScreen *screen);
+
+private:
+    const QByteArray m_nativeEventType = QByteArrayLiteral("xcb_generic_event_t");
+
+    xcb_atom_t m_sysTraySelectionAtom = XCB_ATOM_NONE;
+
+    static QXcbScreen *qPlatformScreenForWindow(QWindow *window);
+
+    QList<QXcbNativeInterfaceHandler *> m_handlers;
+    NativeResourceForIntegrationFunction handlerNativeResourceFunctionForIntegration(const QByteArray &resource) const;
+    NativeResourceForContextFunction handlerNativeResourceFunctionForContext(const QByteArray &resource) const;
+    NativeResourceForScreenFunction handlerNativeResourceFunctionForScreen(const QByteArray &resource) const;
+    NativeResourceForWindowFunction handlerNativeResourceFunctionForWindow(const QByteArray &resource) const;
+    NativeResourceForBackingStoreFunction handlerNativeResourceFunctionForBackingStore(const QByteArray &resource) const;
+    QFunctionPointer handlerPlatformFunction(const QByteArray &function) const;
+    void *handlerNativeResourceForIntegration(const QByteArray &resource) const;
+    void *handlerNativeResourceForContext(const QByteArray &resource, QOpenGLContext *context) const;
+    void *handlerNativeResourceForScreen(const QByteArray &resource, QScreen *screen) const;
+    void *handlerNativeResourceForWindow(const QByteArray &resource, QWindow *window) const;
+    void *handlerNativeResourceForBackingStore(const QByteArray &resource, QBackingStore *backingStore) const;
+};
+
+QT_END_NAMESPACE
+
+#endif // QXCBNATIVEINTERFACE_H

--- a/xcb/libqt5xcbqpa-dev/5.15.4/qxcbobject.h
+++ b/xcb/libqt5xcbqpa-dev/5.15.4/qxcbobject.h
@@ -1,0 +1,64 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of the plugins of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 2.0 or (at your option) the GNU General
+** Public license version 3 or any later version approved by the KDE Free
+** Qt Foundation. The licenses are as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
+** included in the packaging of this file. Please review the following
+** information to ensure the GNU General Public License requirements will
+** be met: https://www.gnu.org/licenses/gpl-2.0.html and
+** https://www.gnu.org/licenses/gpl-3.0.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef QXCBOBJECT_H
+#define QXCBOBJECT_H
+
+#include "qxcbconnection.h"
+
+QT_BEGIN_NAMESPACE
+
+class QXcbObject
+{
+public:
+    QXcbObject(QXcbConnection *connection = nullptr) : m_connection(connection) {}
+
+    void setConnection(QXcbConnection *connection) { m_connection = connection; }
+    QXcbConnection *connection() const { return m_connection; }
+
+    xcb_atom_t atom(QXcbAtom::Atom atom) const { return m_connection->atom(atom); }
+    xcb_connection_t *xcb_connection() const { return m_connection->xcb_connection(); }
+
+private:
+    QXcbConnection *m_connection;
+};
+
+QT_END_NAMESPACE
+
+#endif

--- a/xcb/libqt5xcbqpa-dev/5.15.4/qxcbscreen.h
+++ b/xcb/libqt5xcbqpa-dev/5.15.4/qxcbscreen.h
@@ -1,0 +1,242 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of the plugins of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 2.0 or (at your option) the GNU General
+** Public license version 3 or any later version approved by the KDE Free
+** Qt Foundation. The licenses are as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
+** included in the packaging of this file. Please review the following
+** information to ensure the GNU General Public License requirements will
+** be met: https://www.gnu.org/licenses/gpl-2.0.html and
+** https://www.gnu.org/licenses/gpl-3.0.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef QXCBSCREEN_H
+#define QXCBSCREEN_H
+
+#include <qpa/qplatformscreen.h>
+#include <QtCore/QString>
+
+#include <xcb/xcb.h>
+#include <xcb/randr.h>
+#include <xcb/xfixes.h>
+#include <xcb/xinerama.h>
+
+#include "qxcbobject.h"
+#include "qxcbscreen.h"
+
+#include <private/qfontengine_p.h>
+
+#include <QtEdidSupport/private/qedidparser_p.h>
+
+QT_BEGIN_NAMESPACE
+
+class QXcbConnection;
+class QXcbCursor;
+class QXcbXSettings;
+#ifndef QT_NO_DEBUG_STREAM
+class QDebug;
+#endif
+
+class QXcbVirtualDesktop : public QXcbObject
+{
+public:
+    QXcbVirtualDesktop(QXcbConnection *connection, xcb_screen_t *screen, int number);
+    ~QXcbVirtualDesktop();
+
+    xcb_screen_t *screen() const { return m_screen; }
+    int number() const { return m_number; }
+    QSize size() const { return QSize(m_screen->width_in_pixels, m_screen->height_in_pixels); }
+    QSize physicalSize() const { return QSize(m_screen->width_in_millimeters, m_screen->height_in_millimeters); }
+    QDpi dpi() const;
+    xcb_window_t root() const { return m_screen->root; }
+    QXcbScreen *screenAt(const QPoint &pos) const;
+
+    QList<QPlatformScreen *> screens() const { return m_screens; }
+    void setScreens(QList<QPlatformScreen *> &&sl) { m_screens = std::move(sl); }
+    void removeScreen(QPlatformScreen *s) { m_screens.removeOne(s); }
+    void addScreen(QPlatformScreen *s);
+    void setPrimaryScreen(QPlatformScreen *s);
+
+    QXcbXSettings *xSettings() const;
+
+    bool compositingActive() const;
+
+    void updateWorkArea();
+    QRect availableGeometry(const QRect &screenGeometry) const;
+
+    void handleXFixesSelectionNotify(xcb_xfixes_selection_notify_event_t *notify_event);
+    void subscribeToXFixesSelectionNotify();
+
+    void handleScreenChange(xcb_randr_screen_change_notify_event_t *change_event);
+
+    int forcedDpi() const { return m_forcedDpi; }
+    QFontEngine::HintStyle hintStyle() const { return m_hintStyle; }
+    QFontEngine::SubpixelAntialiasingType subpixelType() const { return m_subpixelType; }
+    int antialiasingEnabled() const { return m_antialiasingEnabled; }
+
+    QString windowManagerName() const { return m_windowManagerName; }
+
+    QSurfaceFormat surfaceFormatFor(const QSurfaceFormat &format) const;
+
+    const xcb_visualtype_t *visualForFormat(const QSurfaceFormat &format) const;
+    const xcb_visualtype_t *visualForId(xcb_visualid_t) const;
+    quint8 depthOfVisual(xcb_visualid_t) const;
+    xcb_colormap_t colormapForVisual(xcb_visualid_t) const;
+
+private:
+    QRect getWorkArea() const;
+
+    static bool xResource(const QByteArray &identifier,
+                          const QByteArray &expectedIdentifier,
+                          QByteArray &stringValue);
+    void readXResources();
+
+    xcb_screen_t *m_screen;
+    const int m_number;
+    QList<QPlatformScreen *> m_screens;
+
+    QXcbXSettings *m_xSettings = nullptr;
+    xcb_atom_t m_net_wm_cm_atom = 0;
+    bool m_compositingActive = false;
+
+    QRect m_workArea;
+
+    int m_forcedDpi = -1;
+    QFontEngine::HintStyle m_hintStyle = QFontEngine::HintStyle(-1);
+    QFontEngine::SubpixelAntialiasingType m_subpixelType = QFontEngine::SubpixelAntialiasingType(-1);
+    int m_antialiasingEnabled = -1;
+    QString m_windowManagerName;
+    QMap<xcb_visualid_t, xcb_visualtype_t> m_visuals;
+    QMap<xcb_visualid_t, quint8> m_visualDepths;
+    mutable QMap<xcb_visualid_t, xcb_colormap_t> m_visualColormaps;
+    uint16_t m_rotation = 0;
+};
+
+class Q_XCB_EXPORT QXcbScreen : public QXcbObject, public QPlatformScreen
+{
+public:
+    QXcbScreen(QXcbConnection *connection, QXcbVirtualDesktop *virtualDesktop,
+               xcb_randr_output_t outputId, xcb_randr_get_output_info_reply_t *outputInfo,
+               const xcb_xinerama_screen_info_t *xineramaScreenInfo = nullptr, int xineramaScreenIdx = -1);
+    ~QXcbScreen();
+
+    QString getOutputName(xcb_randr_get_output_info_reply_t *outputInfo);
+
+    QPixmap grabWindow(WId window, int x, int y, int width, int height) const override;
+
+    QWindow *topLevelAt(const QPoint &point) const override;
+
+    QString manufacturer() const override;
+    QString model() const override;
+    QString serialNumber() const override;
+
+    QRect geometry() const override { return m_geometry; }
+    QRect availableGeometry() const override;
+    int depth() const override { return screen()->root_depth; }
+    QImage::Format format() const override;
+    QSizeF physicalSize() const override { return m_sizeMillimeters; }
+    QDpi logicalDpi() const override;
+    QDpi logicalBaseDpi() const override { return QDpi(96, 96); };
+    QPlatformCursor *cursor() const override;
+    qreal refreshRate() const override { return m_refreshRate; }
+    Qt::ScreenOrientation orientation() const override { return m_orientation; }
+    QList<QPlatformScreen *> virtualSiblings() const override { return m_virtualDesktop->screens(); }
+    QXcbVirtualDesktop *virtualDesktop() const { return m_virtualDesktop; }
+
+    void setPrimary(bool primary) { m_primary = primary; }
+    bool isPrimary() const { return m_primary; }
+
+    int screenNumber() const { return m_virtualDesktop->number(); }
+    static int virtualDesktopNumberStatic(const QScreen *screen);
+
+    xcb_screen_t *screen() const { return m_virtualDesktop->screen(); }
+    xcb_window_t root() const { return screen()->root; }
+    xcb_randr_output_t output() const { return m_output; }
+    xcb_randr_crtc_t crtc() const { return m_crtc; }
+    xcb_randr_mode_t mode() const { return m_mode; }
+
+    void setOutput(xcb_randr_output_t outputId,
+                   xcb_randr_get_output_info_reply_t *outputInfo);
+    void setCrtc(xcb_randr_crtc_t crtc) { m_crtc = crtc; }
+
+    void windowShown(QXcbWindow *window);
+    QString windowManagerName() const { return m_virtualDesktop->windowManagerName(); }
+
+    QSurfaceFormat surfaceFormatFor(const QSurfaceFormat &format) const;
+
+    const xcb_visualtype_t *visualForFormat(const QSurfaceFormat &format) const { return m_virtualDesktop->visualForFormat(format); }
+    const xcb_visualtype_t *visualForId(xcb_visualid_t visualid) const;
+    xcb_colormap_t colormapForVisual(xcb_visualid_t visualid) const { return m_virtualDesktop->colormapForVisual(visualid); }
+    quint8 depthOfVisual(xcb_visualid_t visualid) const { return m_virtualDesktop->depthOfVisual(visualid); }
+
+    QString name() const override { return m_outputName; }
+
+    void updateGeometry(const QRect &geometry, uint8_t rotation);
+    void updateGeometry(xcb_timestamp_t timestamp = XCB_TIME_CURRENT_TIME);
+    void updateAvailableGeometry();
+    void updateRefreshRate(xcb_randr_mode_t mode);
+
+    QFontEngine::HintStyle hintStyle() const { return m_virtualDesktop->hintStyle(); }
+    QFontEngine::SubpixelAntialiasingType subpixelType() const { return m_virtualDesktop->subpixelType(); }
+    int antialiasingEnabled() const { return m_virtualDesktop->antialiasingEnabled(); }
+
+    QXcbXSettings *xSettings() const;
+
+private:
+    void sendStartupMessage(const QByteArray &message) const;
+    int forcedDpi() const;
+
+    QByteArray getOutputProperty(xcb_atom_t atom) const;
+    QByteArray getEdid() const;
+
+    QXcbVirtualDesktop *m_virtualDesktop;
+    xcb_randr_output_t m_output;
+    xcb_randr_crtc_t m_crtc;
+    xcb_randr_mode_t m_mode = XCB_NONE;
+    bool m_primary = false;
+
+    QString m_outputName;
+    QSizeF m_outputSizeMillimeters;
+    QSizeF m_sizeMillimeters;
+    QRect m_geometry;
+    QRect m_availableGeometry;
+    Qt::ScreenOrientation m_orientation = Qt::PrimaryOrientation;
+    QXcbCursor *m_cursor;
+    qreal m_refreshRate = 60.0;
+    QEdidParser m_edid;
+};
+
+#ifndef QT_NO_DEBUG_STREAM
+Q_GUI_EXPORT QDebug operator<<(QDebug, const QXcbScreen *);
+#endif
+
+QT_END_NAMESPACE
+
+#endif

--- a/xcb/libqt5xcbqpa-dev/5.15.4/qxcbsessionmanager.h
+++ b/xcb/libqt5xcbqpa-dev/5.15.4/qxcbsessionmanager.h
@@ -1,0 +1,94 @@
+/****************************************************************************
+**
+** Copyright (C) 2013 Teo Mrnjavac <teo@kde.org>
+** Copyright (C) 2016 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of the plugins of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 2.0 or (at your option) the GNU General
+** Public license version 3 or any later version approved by the KDE Free
+** Qt Foundation. The licenses are as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
+** included in the packaging of this file. Please review the following
+** information to ensure the GNU General Public License requirements will
+** be met: https://www.gnu.org/licenses/gpl-2.0.html and
+** https://www.gnu.org/licenses/gpl-3.0.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef QXCBSESSIONMANAGER_H
+#define QXCBSESSIONMANAGER_H
+
+//
+//  W A R N I N G
+//  -------------
+//
+// This file is part of the QPA API and is not meant to be used
+// in applications. Usage of this API may make your code
+// source and binary incompatible with future versions of Qt.
+//
+
+#include <qpa/qplatformsessionmanager.h>
+
+#ifndef QT_NO_SESSIONMANAGER
+
+QT_BEGIN_NAMESPACE
+
+class QEventLoop;
+
+class QXcbSessionManager : public QPlatformSessionManager
+{
+public:
+    QXcbSessionManager(const QString &id, const QString &key);
+    virtual ~QXcbSessionManager();
+
+    void *handle() const;
+
+    void setSessionId(const QString &id) { m_sessionId = id; }
+    void setSessionKey(const QString &key) { m_sessionKey = key; }
+
+    bool allowsInteraction() override;
+    bool allowsErrorInteraction() override;
+    void release() override;
+
+    void cancel() override;
+
+    void setManagerProperty(const QString &name, const QString &value) override;
+    void setManagerProperty(const QString &name, const QStringList &value) override;
+
+    bool isPhase2() const override;
+    void requestPhase2() override;
+
+    void exitEventLoop();
+
+private:
+    QEventLoop *m_eventLoop;
+};
+
+QT_END_NAMESPACE
+
+#endif //QT_NO_SESSIONMANAGER
+
+#endif //QXCBSESSIONMANAGER_H

--- a/xcb/libqt5xcbqpa-dev/5.15.4/qxcbsystemtraytracker.h
+++ b/xcb/libqt5xcbqpa-dev/5.15.4/qxcbsystemtraytracker.h
@@ -1,0 +1,85 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of the plugins of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 2.0 or (at your option) the GNU General
+** Public license version 3 or any later version approved by the KDE Free
+** Qt Foundation. The licenses are as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
+** included in the packaging of this file. Please review the following
+** information to ensure the GNU General Public License requirements will
+** be met: https://www.gnu.org/licenses/gpl-2.0.html and
+** https://www.gnu.org/licenses/gpl-3.0.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef QXCBSYSTEMTRAYTRACKER_H
+#define QXCBSYSTEMTRAYTRACKER_H
+
+#include "qxcbconnection.h"
+
+#include <xcb/xcb.h>
+
+QT_BEGIN_NAMESPACE
+
+class QXcbConnection;
+class QScreen;
+
+class QXcbSystemTrayTracker : public QObject, public QXcbWindowEventListener
+{
+    Q_OBJECT
+public:
+    static QXcbSystemTrayTracker *create(QXcbConnection *connection);
+
+    xcb_window_t trayWindow();
+    void requestSystemTrayWindowDock(xcb_window_t window) const;
+
+    void notifyManagerClientMessageEvent(const xcb_client_message_event_t *);
+
+    void handleDestroyNotifyEvent(const xcb_destroy_notify_event_t *) override;
+
+    xcb_visualid_t visualId();
+signals:
+    void systemTrayWindowChanged(QScreen *screen);
+
+private:
+    explicit QXcbSystemTrayTracker(QXcbConnection *connection,
+                                   xcb_atom_t trayAtom,
+                                   xcb_atom_t selection);
+    static xcb_window_t locateTrayWindow(const QXcbConnection *connection, xcb_atom_t selection);
+    void emitSystemTrayWindowChanged();
+    xcb_visualid_t netSystemTrayVisual();
+
+    const xcb_atom_t m_selection;
+    const xcb_atom_t m_trayAtom;
+    QXcbConnection *m_connection;
+    xcb_window_t m_trayWindow = 0;
+};
+
+QT_END_NAMESPACE
+
+#endif // QXCBSYSTEMTRAYTRACKER_H

--- a/xcb/libqt5xcbqpa-dev/5.15.4/qxcbvulkaninstance.h
+++ b/xcb/libqt5xcbqpa-dev/5.15.4/qxcbvulkaninstance.h
@@ -1,0 +1,76 @@
+/****************************************************************************
+**
+** Copyright (C) 2017 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of plugins of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 2.0 or (at your option) the GNU General
+** Public license version 3 or any later version approved by the KDE Free
+** Qt Foundation. The licenses are as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
+** included in the packaging of this file. Please review the following
+** information to ensure the GNU General Public License requirements will
+** be met: https://www.gnu.org/licenses/gpl-2.0.html and
+** https://www.gnu.org/licenses/gpl-3.0.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef QXCBVULKANINSTANCE_H
+#define QXCBVULKANINSTANCE_H
+
+#if defined(VULKAN_H_) && !defined(VK_USE_PLATFORM_XCB_KHR)
+#error "vulkan.h included without xcb WSI"
+#endif
+
+#define VK_USE_PLATFORM_XCB_KHR
+
+#include <QtVulkanSupport/private/qbasicvulkanplatforminstance_p.h>
+#include <QLibrary>
+
+QT_BEGIN_NAMESPACE
+
+class QXcbWindow;
+
+class QXcbVulkanInstance : public QBasicPlatformVulkanInstance
+{
+public:
+    QXcbVulkanInstance(QVulkanInstance *instance);
+    ~QXcbVulkanInstance();
+
+    void createOrAdoptInstance() override;
+    bool supportsPresent(VkPhysicalDevice physicalDevice, uint32_t queueFamilyIndex, QWindow *window) override;
+    void presentQueued(QWindow *window) override;
+
+    VkSurfaceKHR createSurface(QXcbWindow *window);
+
+private:
+    QVulkanInstance *m_instance;
+    PFN_vkGetPhysicalDeviceXcbPresentationSupportKHR m_getPhysDevPresSupport;
+    PFN_vkCreateXcbSurfaceKHR m_createSurface;
+};
+
+QT_END_NAMESPACE
+
+#endif // QXCBVULKANINSTANCE_H

--- a/xcb/libqt5xcbqpa-dev/5.15.4/qxcbvulkanwindow.h
+++ b/xcb/libqt5xcbqpa-dev/5.15.4/qxcbvulkanwindow.h
@@ -1,0 +1,65 @@
+/****************************************************************************
+**
+** Copyright (C) 2017 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of the plugins of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 2.0 or (at your option) the GNU General
+** Public license version 3 or any later version approved by the KDE Free
+** Qt Foundation. The licenses are as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
+** included in the packaging of this file. Please review the following
+** information to ensure the GNU General Public License requirements will
+** be met: https://www.gnu.org/licenses/gpl-2.0.html and
+** https://www.gnu.org/licenses/gpl-3.0.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef QXCBVULKANWINDOW_H
+#define QXCBVULKANWINDOW_H
+
+#include "qxcbwindow.h"
+#include "qxcbvulkaninstance.h"
+
+QT_BEGIN_NAMESPACE
+
+class QXcbVulkanWindow : public QXcbWindow
+{
+public:
+    QXcbVulkanWindow(QWindow *window);
+    ~QXcbVulkanWindow();
+
+    VkSurfaceKHR *surface();
+
+protected:
+    void resolveFormat(const QSurfaceFormat &format) override;
+
+private:
+    VkSurfaceKHR m_surface;
+};
+
+QT_END_NAMESPACE
+
+#endif // QXCBVULKANWINDOW_H

--- a/xcb/libqt5xcbqpa-dev/5.15.4/qxcbwindow.h
+++ b/xcb/libqt5xcbqpa-dev/5.15.4/qxcbwindow.h
@@ -1,0 +1,304 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of the plugins of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 2.0 or (at your option) the GNU General
+** Public license version 3 or any later version approved by the KDE Free
+** Qt Foundation. The licenses are as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
+** included in the packaging of this file. Please review the following
+** information to ensure the GNU General Public License requirements will
+** be met: https://www.gnu.org/licenses/gpl-2.0.html and
+** https://www.gnu.org/licenses/gpl-3.0.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef QXCBWINDOW_H
+#define QXCBWINDOW_H
+
+#include <qpa/qplatformwindow.h>
+#include <QtGui/QSurfaceFormat>
+#include <QtGui/QImage>
+
+#include <xcb/xcb.h>
+#include <xcb/sync.h>
+
+#include "qxcbobject.h"
+
+#include <QtPlatformHeaders/qxcbwindowfunctions.h>
+
+QT_BEGIN_NAMESPACE
+
+class QXcbScreen;
+class QXcbSyncWindowRequest;
+class QIcon;
+
+class Q_XCB_EXPORT QXcbWindow : public QXcbObject, public QXcbWindowEventListener, public QPlatformWindow
+{
+public:
+    enum NetWmState {
+        NetWmStateAbove = 0x1,
+        NetWmStateBelow = 0x2,
+        NetWmStateFullScreen = 0x4,
+        NetWmStateMaximizedHorz = 0x8,
+        NetWmStateMaximizedVert = 0x10,
+        NetWmStateModal = 0x20,
+        NetWmStateStaysOnTop = 0x40,
+        NetWmStateDemandsAttention = 0x80,
+        NetWmStateHidden = 0x100
+    };
+
+    Q_DECLARE_FLAGS(NetWmStates, NetWmState)
+
+    QXcbWindow(QWindow *window);
+    ~QXcbWindow();
+
+    void setGeometry(const QRect &rect) override;
+
+    QMargins frameMargins() const override;
+
+    void setVisible(bool visible) override;
+    void setWindowFlags(Qt::WindowFlags flags) override;
+    void setWindowState(Qt::WindowStates state) override;
+    WId winId() const override;
+    void setParent(const QPlatformWindow *window) override;
+
+    bool isExposed() const override;
+    bool isEmbedded() const override;
+    QPoint mapToGlobal(const QPoint &pos) const override;
+    QPoint mapFromGlobal(const QPoint &pos) const override;
+
+    void setWindowTitle(const QString &title) override;
+    void setWindowIconText(const QString &title);
+    void setWindowIcon(const QIcon &icon) override;
+    void raise() override;
+    void lower() override;
+    void propagateSizeHints() override;
+
+    void requestActivateWindow() override;
+
+    bool setKeyboardGrabEnabled(bool grab) override;
+    bool setMouseGrabEnabled(bool grab) override;
+
+    QSurfaceFormat format() const override;
+
+    bool windowEvent(QEvent *event) override;
+
+    bool startSystemResize(Qt::Edges edges) override;
+    bool startSystemMove() override;
+
+    void setOpacity(qreal level) override;
+    void setMask(const QRegion &region) override;
+
+    void setAlertState(bool enabled) override;
+    bool isAlertState() const override { return m_alertState; }
+
+    xcb_window_t xcb_window() const { return m_window; }
+    uint depth() const { return m_depth; }
+    QImage::Format imageFormat() const { return m_imageFormat; }
+    bool imageNeedsRgbSwap() const { return m_imageRgbSwap; }
+
+    bool handleNativeEvent(xcb_generic_event_t *event)  override;
+
+    void handleExposeEvent(const xcb_expose_event_t *event) override;
+    void handleClientMessageEvent(const xcb_client_message_event_t *event) override;
+    void handleConfigureNotifyEvent(const xcb_configure_notify_event_t *event) override;
+    void handleMapNotifyEvent(const xcb_map_notify_event_t *event) override;
+    void handleUnmapNotifyEvent(const xcb_unmap_notify_event_t *event) override;
+    void handleButtonPressEvent(const xcb_button_press_event_t *event) override;
+    void handleButtonReleaseEvent(const xcb_button_release_event_t *event) override;
+    void handleMotionNotifyEvent(const xcb_motion_notify_event_t *event) override;
+
+    void handleEnterNotifyEvent(const xcb_enter_notify_event_t *event) override;
+    void handleLeaveNotifyEvent(const xcb_leave_notify_event_t *event) override;
+    void handleFocusInEvent(const xcb_focus_in_event_t *event) override;
+    void handleFocusOutEvent(const xcb_focus_out_event_t *event) override;
+    void handlePropertyNotifyEvent(const xcb_property_notify_event_t *event) override;
+    void handleXIMouseEvent(xcb_ge_event_t *, Qt::MouseEventSource source = Qt::MouseEventNotSynthesized) override;
+    void handleXIEnterLeave(xcb_ge_event_t *) override;
+
+    QXcbWindow *toWindow() override;
+
+    void handleMouseEvent(xcb_timestamp_t time, const QPoint &local, const QPoint &global,
+                          Qt::KeyboardModifiers modifiers, QEvent::Type type, Qt::MouseEventSource source);
+
+    void updateNetWmUserTime(xcb_timestamp_t timestamp);
+
+    static void setWmWindowTypeStatic(QWindow *window, QXcbWindowFunctions::WmWindowTypes windowTypes);
+    static void setWmWindowRoleStatic(QWindow *window, const QByteArray &role);
+    static uint visualIdStatic(QWindow *window);
+
+    QXcbWindowFunctions::WmWindowTypes wmWindowTypes() const;
+    void setWmWindowType(QXcbWindowFunctions::WmWindowTypes types, Qt::WindowFlags flags);
+    void setWmWindowRole(const QByteArray &role);
+
+    static void setWindowIconTextStatic(QWindow *window, const QString &text);
+
+    void setParentRelativeBackPixmap();
+    bool requestSystemTrayWindowDock();
+    uint visualId() const;
+
+    bool needsSync() const;
+
+    void postSyncWindowRequest();
+    void clearSyncWindowRequest() { m_pendingSyncRequest = nullptr; }
+
+    QXcbScreen *xcbScreen() const;
+
+    bool startSystemMoveResize(const QPoint &pos, int edges);
+    void doStartSystemMoveResize(const QPoint &globalPos, int edges);
+
+    static bool isTrayIconWindow(QWindow *window)
+    {
+        return window->objectName() == QLatin1String("QSystemTrayIconSysWindow");
+    }
+
+    virtual void create();
+    virtual void destroy();
+
+    static void setWindowTitle(const QXcbConnection *conn, xcb_window_t window, const QString &title);
+    static QString windowTitle(const QXcbConnection *conn, xcb_window_t window);
+
+    int swapInterval() const { return m_swapInterval; }
+    void setSwapInterval(int swapInterval) { m_swapInterval = swapInterval; }
+
+public Q_SLOTS:
+    void updateSyncRequestCounter();
+
+protected:
+    virtual void resolveFormat(const QSurfaceFormat &format) { m_format = format; }
+    virtual const xcb_visualtype_t *createVisual();
+    void setImageFormatForVisual(const xcb_visualtype_t *visual);
+
+    QXcbScreen *parentScreen();
+    QXcbScreen *initialScreen() const;
+
+    void setNetWmState(bool set, xcb_atom_t one, xcb_atom_t two = 0);
+    void setNetWmState(Qt::WindowFlags flags);
+    void setNetWmState(Qt::WindowStates state);
+    void setNetWmStateOnUnmappedWindow();
+    NetWmStates netWmStates();
+
+    void setMotifWmHints(Qt::WindowFlags flags);
+
+    void setTransparentForMouseEvents(bool transparent);
+    void updateDoesNotAcceptFocus(bool doesNotAcceptFocus);
+
+    void sendXEmbedMessage(xcb_window_t window, quint32 message,
+                           quint32 detail = 0, quint32 data1 = 0, quint32 data2 = 0);
+    void handleXEmbedMessage(const xcb_client_message_event_t *event);
+
+    void show();
+    void hide();
+
+    bool relayFocusToModalWindow() const;
+    void doFocusIn();
+    void doFocusOut();
+
+    void handleButtonPressEvent(int event_x, int event_y, int root_x, int root_y,
+                                int detail, Qt::KeyboardModifiers modifiers, xcb_timestamp_t timestamp,
+                                QEvent::Type type, Qt::MouseEventSource source = Qt::MouseEventNotSynthesized);
+
+    void handleButtonReleaseEvent(int event_x, int event_y, int root_x, int root_y,
+                                  int detail, Qt::KeyboardModifiers modifiers, xcb_timestamp_t timestamp,
+                                  QEvent::Type type, Qt::MouseEventSource source = Qt::MouseEventNotSynthesized);
+
+    void handleMotionNotifyEvent(int event_x, int event_y, int root_x, int root_y,
+                                 Qt::KeyboardModifiers modifiers, xcb_timestamp_t timestamp,
+                                 QEvent::Type type, Qt::MouseEventSource source = Qt::MouseEventNotSynthesized);
+
+    void handleEnterNotifyEvent(int event_x, int event_y, int root_x, int root_y,
+                                quint8 mode, quint8 detail, xcb_timestamp_t timestamp);
+
+    void handleLeaveNotifyEvent(int root_x, int root_y,
+                                quint8 mode, quint8 detail, xcb_timestamp_t timestamp);
+
+    xcb_window_t m_window = 0;
+
+    uint m_depth = 0;
+    QImage::Format m_imageFormat = QImage::Format_ARGB32_Premultiplied;
+    bool m_imageRgbSwap = false;
+
+    xcb_sync_int64_t m_syncValue;
+    xcb_sync_counter_t m_syncCounter = 0;
+
+    Qt::WindowStates m_windowState = Qt::WindowNoState;
+
+    bool m_mapped = false;
+    bool m_transparent = false;
+    bool m_deferredActivation = false;
+    bool m_embedded = false;
+    bool m_alertState = false;
+    bool m_minimized = false;
+    bool m_trayIconWindow = false;
+    xcb_window_t m_netWmUserTimeWindow = XCB_NONE;
+
+    QSurfaceFormat m_format;
+
+    mutable bool m_dirtyFrameMargins = false;
+    mutable QMargins m_frameMargins;
+
+    QRegion m_exposeRegion;
+    QSize m_oldWindowSize;
+    QPoint m_lastPointerPosition;
+
+    xcb_visualid_t m_visualId = 0;
+    // Last sent state. Initialized to an invalid state, on purpose.
+    Qt::WindowStates m_lastWindowStateEvent = Qt::WindowActive;
+
+    enum SyncState {
+        NoSyncNeeded,
+        SyncReceived,
+        SyncAndConfigureReceived
+    };
+    SyncState m_syncState = NoSyncNeeded;
+
+    QXcbSyncWindowRequest *m_pendingSyncRequest = nullptr;
+    int m_swapInterval = -1;
+
+    qreal m_sizeHintsScaleFactor = 1.0;
+};
+
+class QXcbForeignWindow : public QXcbWindow
+{
+public:
+    QXcbForeignWindow(QWindow *window, WId nativeHandle)
+        : QXcbWindow(window) { m_window = nativeHandle; }
+    ~QXcbForeignWindow();
+    bool isForeignWindow() const override { return true; }
+
+protected:
+    void create() override {} // No-op
+};
+
+QVector<xcb_rectangle_t> qRegionToXcbRectangleList(const QRegion &region);
+
+QT_END_NAMESPACE
+
+Q_DECLARE_METATYPE(QXcbWindow*)
+
+#endif

--- a/xcb/libqt5xcbqpa-dev/5.15.4/qxcbwmsupport.h
+++ b/xcb/libqt5xcbqpa-dev/5.15.4/qxcbwmsupport.h
@@ -1,0 +1,68 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of the plugins of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 2.0 or (at your option) the GNU General
+** Public license version 3 or any later version approved by the KDE Free
+** Qt Foundation. The licenses are as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
+** included in the packaging of this file. Please review the following
+** information to ensure the GNU General Public License requirements will
+** be met: https://www.gnu.org/licenses/gpl-2.0.html and
+** https://www.gnu.org/licenses/gpl-3.0.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+#ifndef QXCBWMSUPPORT_H
+#define QXCBWMSUPPORT_H
+
+#include "qxcbobject.h"
+#include "qxcbconnection.h"
+#include <qvector.h>
+
+QT_BEGIN_NAMESPACE
+
+class QXcbWMSupport : public QXcbObject
+{
+public:
+    QXcbWMSupport(QXcbConnection *c);
+
+
+    bool isSupportedByWM(xcb_atom_t atom) const;
+    const QVector<xcb_window_t> &virtualRoots() const { return net_virtual_roots; }
+
+private:
+    friend class QXcbConnection;
+    void updateNetWMAtoms();
+    void updateVirtualRoots();
+
+    QVector<xcb_atom_t> net_wm_atoms;
+    QVector<xcb_window_t> net_virtual_roots;
+};
+
+QT_END_NAMESPACE
+
+#endif

--- a/xcb/libqt5xcbqpa-dev/5.15.4/qxcbxsettings.h
+++ b/xcb/libqt5xcbqpa-dev/5.15.4/qxcbxsettings.h
@@ -1,0 +1,71 @@
+/****************************************************************************
+**
+** Copyright (C) 2016 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** This file is part of the plugins of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL3 included in the
+** packaging of this file. Please review the following information to
+** ensure the GNU Lesser General Public License version 3 requirements
+** will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 2.0 or (at your option) the GNU General
+** Public license version 3 or any later version approved by the KDE Free
+** Qt Foundation. The licenses are as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
+** included in the packaging of this file. Please review the following
+** information to ensure the GNU General Public License requirements will
+** be met: https://www.gnu.org/licenses/gpl-2.0.html and
+** https://www.gnu.org/licenses/gpl-3.0.html.
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef QXCBXSETTINGS_H
+#define QXCBXSETTINGS_H
+
+#include "qxcbscreen.h"
+
+QT_BEGIN_NAMESPACE
+
+class QXcbXSettingsPrivate;
+
+class QXcbXSettings : public QXcbWindowEventListener
+{
+    Q_DECLARE_PRIVATE(QXcbXSettings)
+public:
+    QXcbXSettings(QXcbVirtualDesktop *screen);
+    ~QXcbXSettings();
+    bool initialized() const;
+
+    QVariant setting(const QByteArray &property) const;
+
+    typedef void (*PropertyChangeFunc)(QXcbVirtualDesktop *screen, const QByteArray &name, const QVariant &property, void *handle);
+    void registerCallbackForProperty(const QByteArray &property, PropertyChangeFunc func, void *handle);
+    void removeCallbackForHandle(const QByteArray &property, void *handle);
+    void removeCallbackForHandle(void *handle);
+
+    void handlePropertyNotifyEvent(const xcb_property_notify_event_t *event) override;
+private:
+    QXcbXSettingsPrivate *d_ptr;
+};
+
+QT_END_NAMESPACE
+
+#endif // QXCBXSETTINGS_H


### PR DESCRIPTION
Qt 5.15.4 source code is now published, see:

- https://download.qt.io/archive/qt/5.15/5.15.4/
- https://code.qt.io/cgit/qt/qtbase.git/tree/src/plugins/platforms/xcb?h=v5.15.4-lts-lgpl