### PR TITLE
chore: 注释掉 wayland 上的 fakeinput 的调用

### DIFF
--- a/wayland/wayland-shell/dwaylandshellmanager.cpp
+++ b/wayland/wayland-shell/dwaylandshellmanager.cpp
@@ -373,6 +373,7 @@ void DWaylandShellManager::createDDEKeyboard()
     }
 }
 
+#if HAS_FAKEINPUT
 void DWaylandShellManager::createDDEFakeInput()
 {
     kwayland_dde_fake_input = registry()->createFakeInput(registry()->interface(Registry::Interface::FakeInput).name,
@@ -384,6 +385,7 @@ void DWaylandShellManager::createDDEFakeInput()
     // 打开设置光标位置的开关
     kwayland_dde_fake_input->authenticate("dtk", QString("set cursor pos"));
 }
+#endif
 
 void DWaylandShellManager::createDDEPointer()
 {
@@ -423,7 +425,9 @@ void DWaylandShellManager::createDDEPointer()
         }
         releasePos = pos;
 
+#if HAS_FAKEINPUT
         setCursorPoint(pos);
+#endif
         pointerEvent(pos, QEvent::MouseButtonPress);
     });
     QObject::connect(kwayland_dde_touch, &DDETouch::touchMotion, [=] (int32_t kwaylandId, const QPointF &pos) {
@@ -432,7 +436,9 @@ void DWaylandShellManager::createDDEPointer()
         }
         isTouchMotion = true;
         pointerEvent(pos, QEvent::Move);
+#if HAS_FAKEINPUT
         setCursorPoint(pos);
+#endif
         releasePos = pos;
     });
     QObject::connect(kwayland_dde_touch, &DDETouch::touchUp, [=] (int32_t kwaylandId) {
@@ -445,8 +451,9 @@ void DWaylandShellManager::createDDEPointer()
             isTouchMotion = false;
             return;
         }
-
+#if HAS_FAKEINPUT
         setCursorPoint(releasePos);
+#endif
         pointerEvent(releasePos, QEvent::MouseButtonRelease);
     });
 }
@@ -607,6 +614,7 @@ void DWaylandShellManager::setDockStrut(QWaylandShellSurface *surface, const QVa
     kwayland_strut->setStrutPartial(getWindowWLSurface(surface->window()), dockStrut);
 }
 
+#if HAS_FAKEINPUT
 /*
  * @brief setCursorPoint  设置光标在屏幕中的绝对位置
  * @param pos
@@ -622,6 +630,7 @@ void DWaylandShellManager::setCursorPoint(QPointF pos) {
     }
     kwayland_dde_fake_input->requestPointerMoveAbsolute(pos);
 }
+#endif
 
 bool DWaylandShellManager::disableClientDecorations(QWaylandShellSurface *surface)
 {

--- a/wayland/wayland-shell/dwaylandshellmanager.h
+++ b/wayland/wayland-shell/dwaylandshellmanager.h
@@ -19,7 +19,9 @@
 #include <KWayland/Client/ddeseat.h>
 #include <KWayland/Client/ddekeyboard.h>
 #include <KWayland/Client/strut.h>
+#if HAS_FAKEINPUT
 #include <KWayland/Client/fakeinput.h>
+#endif
 
 #include <QGuiApplication>
 #include <QPointer>
@@ -62,7 +64,9 @@ public:
     static void createStrut(quint32 name, quint32 version);
     static void createDDEPointer();
     static void createDDEKeyboard();
+#if HAS_FAKEINPUT
     static void createDDEFakeInput();
+#endif
     static void handleGeometryChange(QWaylandWindow *window);
     static void handleWindowStateChanged(QWaylandWindow *window);
     static void setWindowStaysOnTop(QWaylandShellSurface *surface, const bool state);

--- a/wayland/wayland-shell/main.cpp
+++ b/wayland/wayland-shell/main.cpp
@@ -68,7 +68,9 @@ QWaylandShellIntegration *QKWaylandShellIntegrationPlugin::create(const QString 
     connect(registry, &KWayland::Client::Registry::interfacesAnnounced, [] {
         DWaylandShellManager::createDDEPointer();
         DWaylandShellManager::createDDEKeyboard();
+#if HAS_FAKEINPUT
         DWaylandShellManager::createDDEFakeInput();
+#endif
     });
 
     connect(registry, &KWayland::Client::Registry::strutAnnounced,

--- a/wayland/wayland-shell/wayland-shell.pro
+++ b/wayland/wayland-shell/wayland-shell.pro
@@ -25,7 +25,7 @@ qtCompileTest(deepin-kwin-test) {
 }
 
 DESTDIR = $$_PRO_FILE_PWD_/../../bin/plugins/wayland-shell-integration
-DEFINES += QT5DWAYLANDPLUGIN_LIBRARY
+DEFINES += QT5DWAYLANDPLUGIN_LIBRARY HAS_FAKEINPUT=0
 
 # The following define makes your compiler emit warnings if you use
 # any feature of Qt which has been marked as deprecated (the exact warnings


### PR DESCRIPTION
最新版的已经不存在光标不能跟随触摸位置的问题了

Log:
Influence: wayland上的触摸操作