### PR TITLE
chore: 支持v23版本创建xdg-shell

### DIFF
--- a/wayland/wayland-shell/main.cpp
+++ b/wayland/wayland-shell/main.cpp
@@ -44,6 +44,12 @@ QWaylandShellIntegration *QKWaylandShellIntegrationPlugin::create(const QString 
     Q_UNUSED(paramList)
     auto wayland_integration = static_cast<QWaylandIntegration *>(QGuiApplicationPrivate::platformIntegration());
     auto shell = wayland_integration->createShellIntegration("xdg-shell-v6");
+    if (!shell) {
+        shell = wayland_integration->createShellIntegration("xdg-shell");
+    }
+    if (!shell) {
+        return nullptr;
+    }
 
     HookOverride(shell, &QWaylandShellIntegration::createShellSurface, DWaylandShellManager::createShellSurface);
 


### PR DESCRIPTION
v23版本xdg-shell-v6废弃，创建失败则创建xdg-shell

Log:
Influence: