### PR TITLE
chore: 修改windowEvent事件处理返回值

### DIFF
--- a/wayland/dwayland/dnotitlebarwindowhelper_wl.cpp
+++ b/wayland/dwayland/dnotitlebarwindowhelper_wl.cpp
@@ -187,7 +187,9 @@ bool DNoTitlebarWlWindowHelper::windowEvent(QWindow *w, QEvent *event, DNoTitleb
         self->m_windowMoving = false;
     }
 
-    bool ret = HookCall(w, &QWindow::event, event);
+    if (!HookCall(w, &QWindow::event, event)) {
+        return false;
+    }
 
     // workaround for kwin: Qt receives no release event when kwin finishes MOVE operation,
     // which makes app hang in windowMoving state. when a press happens, there's no sense of
@@ -206,7 +208,7 @@ bool DNoTitlebarWlWindowHelper::windowEvent(QWindow *w, QEvent *event, DNoTitleb
         }
     }
 
-    return ret;
+    return true;
 }
 
 bool DNoTitlebarWlWindowHelper::isEnableSystemMove(/*quint32 winId*/)


### PR DESCRIPTION
当窗口内部返回false的时候不继续往下执行

Log:
Influence: 鼠标拖动窗口移动