### PR TITLE
chore: dde-qt5wayland-plugin 运行依赖加上 qtwayland5

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -25,6 +25,6 @@ Description: Qt platform plugins
 
 Package: dde-qt5wayland-plugin
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}, qtwayland5
 Description: Qt platform plugins
  Qt platform plugins for DDE.


### PR DESCRIPTION
debian/control:dde-qt5wayland-plugin 运行依赖加上 qtwayland5

Log: dde-qt5wayland-plugin 运行依赖加上 qtwayland5
Task: https://pms.uniontech.com/task-view-147965.html
Influence: dde-qt5wayland-plugin 运行依赖