### PR TITLE
fix(build): qtwayland 5.15 build error

### DIFF
--- a/wayland/wayland-shell/dkeyboard.cpp
+++ b/wayland/wayland-shell/dkeyboard.cpp
@@ -52,8 +52,12 @@ static void handleKey(QWindow *window, ulong timestamp, QEvent::Type type, int k
     QPlatformInputContext *inputContext = QGuiApplicationPrivate::platformIntegration()->inputContext();
     bool filtered = false;
 
+    bool usingInputContextFromCompositor = true;
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
     QWaylandDisplay *display = static_cast<QWaylandIntegration *>(QGuiApplicationPrivate::platformIntegration())->display();
-    if (inputContext && display && !display->usingInputContextFromCompositor()) {
+    usingInputContextFromCompositor = display && !display->usingInputContextFromCompositor();
+#endif
+    if (inputContext && usingInputContextFromCompositor) {
         QKeyEvent event(type, key, modifiers, nativeScanCode, nativeVirtualKey,
                         nativeModifiers, text, autorepeat, count);
         event.setTimestamp(timestamp);


### PR DESCRIPTION
QtWaylandClient::QWaylandDisplay' has no member named
'usingInputContextFromCompositor'

Log: fix build error
Influence: Qt5.15 build
Change-Id: I12caa9ce25664f02f44cc41a0781ca32977dcd21