### PR TITLE
fix: 锁屏界面网络面板显示异常，底色有重叠黑影

### DIFF
--- a/wayland/wayland-shell/dwaylandshellmanager.h
+++ b/wayland/wayland-shell/dwaylandshellmanager.h
@@ -20,6 +20,10 @@
 #include <KWayland/Client/ddekeyboard.h>
 #include <KWayland/Client/strut.h>
 #include <KWayland/Client/fakeinput.h>
+#include <KWayland/Client/compositor.h>
+#include <KWayland/Client/blur.h>
+#include <KWayland/Client/region.h>
+#include <KWayland/Client/surface.h>
 
 #include <QGuiApplication>
 #include <QPointer>
@@ -32,6 +36,37 @@ DPP_USE_NAMESPACE
 using namespace KWayland::Client;
 
 namespace QtWaylandClient {
+
+struct BlurArea {
+    qint32 x;
+    qint32 y;
+    qint32 width;
+    qint32 height;
+    qint32 xRadius;
+    qint32 yRaduis;
+
+    inline BlurArea operator *(qreal scale)
+    {
+        if (qFuzzyCompare(1.0, scale))
+            return *this;
+
+        BlurArea new_area;
+
+        new_area.x = qRound64(x * scale);
+        new_area.y = qRound64(y * scale);
+        new_area.width = qRound64(width * scale);
+        new_area.height = qRound64(height * scale);
+        new_area.xRadius = qRound64(xRadius * scale);
+        new_area.yRaduis = qRound64(yRaduis * scale);
+
+        return new_area;
+    }
+
+    inline BlurArea &operator *=(qreal scale)
+    {
+        return *this = *this * scale;
+    }
+};
 
 class DWaylandShellManager
 {
@@ -64,15 +99,21 @@ public:
     static void createDDEPointer();
     static void createDDEKeyboard();
     static void createDDEFakeInput();
+    static void createBlurManager(quint32 name, quint32 version);
+    static void createCompositor(quint32 name, quint32 version);
+    static void createSurface();
     static void handleGeometryChange(QWaylandWindow *window);
     static void handleWindowStateChanged(QWaylandWindow *window);
     static void setWindowStaysOnTop(QWaylandShellSurface *surface, const bool state);
     static void setDockStrut(QWaylandShellSurface *surface, const QVariant var);
     static void setCursorPoint(QPointF pos);
+    static void setEnableBlurWidow(QWaylandWindow *wlWindow);
+    static void updateWindowBlurAreasForWM(QWaylandWindow *wlWindow, const QString &name, const QVariant &value);
 
 private:
     // 用于记录设置过以_DWAYALND_开头的属性，当kwyalnd_shell对象创建以后要使这些属性生效
     static QList<QPointer<QWaylandWindow>> send_property_window_list;
+    static bool m_enableBlurWidow;
 };
 }
 

--- a/wayland/wayland-shell/main.cpp
+++ b/wayland/wayland-shell/main.cpp
@@ -100,6 +100,15 @@ QWaylandShellIntegration *QKWaylandShellIntegrationPlugin::create(const QString 
     connect(registry, &Registry::strutAnnounced,
             &DWaylandShellManager::createStrut);
 
+    connect(registry, &Registry::blurAnnounced, [](quint32 name, quint32 version) {
+        DWaylandShellManager::createBlurManager(name, version);
+    });
+
+    connect(registry, &Registry::compositorAnnounced, [](quint32 name, quint32 version){
+        DWaylandShellManager::createCompositor(name, version);
+        DWaylandShellManager::createSurface();
+    });
+
     wl_display *wlDisplay = reinterpret_cast<wl_display*>(platformNativeDisplay);
 
     registry->create(wlDisplay);


### PR DESCRIPTION
创建blur模块，通过clipPath属性传的region设置模糊区

Log: 修复锁屏界面网络面板显示异常，底色有重叠黑影问题
Bug: https://pms.uniontech.com/bug-view-124427.html
Influence: darrowRectangle
Change-Id: I27b19539c3f228e83d36246e8f39cbd9e76e88ed