### PR TITLE
fix: wayland控制中心时区背景模糊问题

### DIFF
--- a/wayland/wayland-shell/dwaylandshellmanager.cpp
+++ b/wayland/wayland-shell/dwaylandshellmanager.cpp
@@ -1,6 +1,7 @@
 #include "dwaylandshellmanager.h"
 #include "dkeyboard.h"
 #include "global.h"
+#include "../xcb/utility.h"
 
 
 #define protected public
@@ -46,7 +47,6 @@ namespace {
 };
 
 QList<QPointer<QWaylandWindow>> DWaylandShellManager::send_property_window_list;
-bool DWaylandShellManager::m_enableBlurWidow = false;
 
 inline static wl_surface *getWindowWLSurface(QWaylandWindow *window)
 {
@@ -215,8 +215,7 @@ void DWaylandShellManager::sendProperty(QWaylandShellSurface *self, const QStrin
                 qCWarning(dwlp) << "invalid enableBlurWindow";
                 return;
             }
-            m_enableBlurWidow = value.toBool();
-            setEnableBlurWidow(wlWindow);
+            setEnableBlurWidow(wlWindow, value);
         }
         if (!name.compare(windowBlurAreas) || !name.compare(windowBlurPaths)) {
             qCDebug(dwlp) << "### requestWindowBlur" << name << value;
@@ -730,10 +729,10 @@ void DWaylandShellManager::setCursorPoint(QPointF pos) {
     kwayland_dde_fake_input->requestPointerMoveAbsolute(pos);
 }
 
-void DWaylandShellManager::setEnableBlurWidow(QWaylandWindow *wlWindow)
+void DWaylandShellManager::setEnableBlurWidow(QWaylandWindow *wlWindow, const QVariant &value)
 {
     auto surface = ensureSurface(wlWindow);
-    if (m_enableBlurWidow) {
+    if (value.toBool()) {
         auto blur = ensureBlur(surface, surface);
         if (!blur) {
             qCWarning(dwlp) << "invalid blur";
@@ -761,6 +760,15 @@ void DWaylandShellManager::setEnableBlurWidow(QWaylandWindow *wlWindow)
 
 void DWaylandShellManager::updateWindowBlurAreasForWM(QWaylandWindow *wlWindow, const QString &name, const QVariant &value)
 {
+    if (!wlWindow->waylandScreen()) {
+        return;
+    }
+    auto screen = wlWindow->waylandScreen()->screen();
+    if (!screen) {
+        return;
+    }
+    auto devicePixelRatio = screen->devicePixelRatio();
+
     auto surface = ensureSurface(wlWindow);
     if (!surface) {
         qCWarning(dwlp) << "invalid surface";
@@ -771,30 +779,20 @@ void DWaylandShellManager::updateWindowBlurAreasForWM(QWaylandWindow *wlWindow, 
         qCWarning(dwlp) << "invalid blur";
         return;
     }
-    auto region = ensureRegion(surface);
-    if (!region) {
-        qCWarning(dwlp) << "invalid region";
-        return;
-    }
+    auto region = kwayland_compositor->createRegion(surface);
 
-    if (m_enableBlurWidow) {
-        blur->setRegion(region);
-        blur->commit();
-        kwayland_surface->commit(Surface::CommitFlag::None);
-        return;
-    }
     if (!name.compare(windowBlurAreas)) {
         const QVector<quint32> &tmpV = qvariant_cast<QVector<quint32>>(value);
-        const QVector<BlurArea> &blurAreas = *(reinterpret_cast<const QVector<BlurArea>*>(&tmpV));
+        const QVector<Utility::BlurArea> &blurAreas = *(reinterpret_cast<const QVector<Utility::BlurArea>*>(&tmpV));
         if (blurAreas.isEmpty()) {
             qCWarning(dwlp) << "invalid BlurAreas";
             return;
         }
         for (auto ba : blurAreas) {
+            ba *= devicePixelRatio;
             QPainterPath path;
             path.addRoundedRect(ba.x, ba.y, ba.width, ba.height, ba.xRadius, ba.yRaduis);
             region->add(path.toFillPolygon().toPolygon());
-            qCDebug(dwlp) << "blurArea:" << path;
         }
     } else {
         const QList<QPainterPath> paths = qvariant_cast<QList<QPainterPath>>(value);
@@ -803,9 +801,9 @@ void DWaylandShellManager::updateWindowBlurAreasForWM(QWaylandWindow *wlWindow, 
             return;
         }
         for (auto path : paths) {
+            path *= devicePixelRatio;
             QPolygon polygon(path.toFillPolygon().toPolygon());
             region->add(polygon);
-            qCDebug(dwlp) << "blurPaths:" << polygon;
         }
     }
     blur->setRegion(region);

--- a/wayland/wayland-shell/dwaylandshellmanager.h
+++ b/wayland/wayland-shell/dwaylandshellmanager.h
@@ -10,6 +10,7 @@
 #include "QtWaylandClient/private/qwaylandshellsurface_p.h"
 #include "QtWaylandClient/private/qwaylandwindow_p.h"
 #include "QtWaylandClient/private/qwaylandcursor_p.h"
+#include "QtWaylandClient/private/qwaylandscreen_p.h"
 #undef private
 
 #include <KWayland/Client/registry.h>
@@ -36,37 +37,6 @@ DPP_USE_NAMESPACE
 using namespace KWayland::Client;
 
 namespace QtWaylandClient {
-
-struct BlurArea {
-    qint32 x;
-    qint32 y;
-    qint32 width;
-    qint32 height;
-    qint32 xRadius;
-    qint32 yRaduis;
-
-    inline BlurArea operator *(qreal scale)
-    {
-        if (qFuzzyCompare(1.0, scale))
-            return *this;
-
-        BlurArea new_area;
-
-        new_area.x = qRound64(x * scale);
-        new_area.y = qRound64(y * scale);
-        new_area.width = qRound64(width * scale);
-        new_area.height = qRound64(height * scale);
-        new_area.xRadius = qRound64(xRadius * scale);
-        new_area.yRaduis = qRound64(yRaduis * scale);
-
-        return new_area;
-    }
-
-    inline BlurArea &operator *=(qreal scale)
-    {
-        return *this = *this * scale;
-    }
-};
 
 class DWaylandShellManager
 {
@@ -107,13 +77,12 @@ public:
     static void setWindowStaysOnTop(QWaylandShellSurface *surface, const bool state);
     static void setDockStrut(QWaylandShellSurface *surface, const QVariant var);
     static void setCursorPoint(QPointF pos);
-    static void setEnableBlurWidow(QWaylandWindow *wlWindow);
+    static void setEnableBlurWidow(QWaylandWindow *wlWindow, const QVariant &value);
     static void updateWindowBlurAreasForWM(QWaylandWindow *wlWindow, const QString &name, const QVariant &value);
 
 private:
     // 用于记录设置过以_DWAYALND_开头的属性，当kwyalnd_shell对象创建以后要使这些属性生效
     static QList<QPointer<QWaylandWindow>> send_property_window_list;
-    static bool m_enableBlurWidow;
 };
 }
 


### PR DESCRIPTION
1.绘制模糊区域时重新创建region。
2.模糊去使能和窗口綁定。

Log: 解決wayland控制中心时区背景模糊问题
Bug: https://pms.uniontech.com/bug-view-126387.html
Influence: 时区模糊背景
Change-Id: I12435abbb47c9aa2762ac783b15e701cdd347481