### PR TITLE
fix: 当主屏发生变化后，及时更新到xsettings

### DIFF
--- a/wayland/dwayland/dwaylandintegration.cpp
+++ b/wayland/dwayland/dwaylandintegration.cpp
@@ -148,6 +148,8 @@ static void onPrimaryScreenChanged(xcb_connection_t *connection, const QByteArra
             if (screen->model().startsWith(primaryScreenName)) {
 #if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
                 QWindowSystemInterface::handlePrimaryScreenChanged(screen);
+#else
+                DWaylandIntegration::instance()->setPrimaryScreen(screen);
 #endif
             }
         }
@@ -220,5 +222,12 @@ QVariant DWaylandIntegration::styleHint(QPlatformIntegration::StyleHint hint) co
 
     return QtWaylandClient::QWaylandIntegration::styleHint(hint);
 }
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 12, 0)
+void DWaylandIntegration::setPrimaryScreen(QPlatformScreen *newPrimary)
+{
+    return QPlatformIntegration::setPrimaryScreen(newPrimary);
+}
+#endif
 
 DPP_END_NAMESPACE

--- a/wayland/dwayland/dwaylandintegration.h
+++ b/wayland/dwayland/dwaylandintegration.h
@@ -39,6 +39,10 @@ public:
     void initialize() override;
     QStringList themeNames() const override;
     QVariant styleHint(StyleHint hint) const override;
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 12, 0)
+    void setPrimaryScreen(QPlatformScreen *newPrimary);
+#endif
 };
 
 DPP_END_NAMESPACE


### PR DESCRIPTION
dwayland通过xsettings获取主屏信息的变化，用于实现wayland下主屏设置功能
确保qt接口和display服务的主屏数据一致

Log: 解决wayland下主屏功能异常问题
Influence: 当主屏发生变化后，及时更新到xsettings
Bug: https://pms.uniontech.com/bug-view-146451.html
Change-Id: I25ad8568e16e2b40534a036688866af25910342d