### PR TITLE
chore: 判断是否支持xdg-shell-v6

### DIFF
--- a/wayland/wayland-shell/main.cpp
+++ b/wayland/wayland-shell/main.cpp
@@ -66,14 +66,6 @@ QWaylandShellIntegration *QKWaylandShellIntegrationPlugin::create(const QString 
 {
     Q_UNUSED(key)
     Q_UNUSED(paramList)
-    auto wayland_integration = static_cast<QWaylandIntegration *>(QGuiApplicationPrivate::platformIntegration());
-    QString shellVersion = qgetenv("ENABLE_XDG_SHELL").isEmpty() ? "xdg-shell-v6" : "xdg-shell";
-    QWaylandShellIntegration *shell = wayland_integration->createShellIntegration(shellVersion);
-
-    if (!shell)
-        return nullptr;
-
-    HookOverride(shell, &QWaylandShellIntegration::createShellSurface, DWaylandShellManager::createShellSurface);
 
     Registry *registry = DWaylandShellManager::registry();
 
@@ -115,6 +107,15 @@ QWaylandShellIntegration *QKWaylandShellIntegrationPlugin::create(const QString 
     registry->setup();
 
     wl_display_roundtrip(wlDisplay);
+
+    auto wayland_integration = static_cast<QWaylandIntegration *>(QGuiApplicationPrivate::platformIntegration());
+    QString shellVersion = registry->hasInterface(Registry::Interface::XdgShellUnstableV6) ? "xdg-shell-v6" : "xdg-shell";
+    QWaylandShellIntegration *shell = wayland_integration->createShellIntegration(shellVersion);
+
+    if (!shell)
+        return nullptr;
+
+    HookOverride(shell, &QWaylandShellIntegration::createShellSurface, DWaylandShellManager::createShellSurface);
 
     return shell;
 }


### PR DESCRIPTION
修改对环境变量的判断为
对是否支持xdg-shell-v6接口的判断

Log: 修改对xdg-shell-v6的判断
Influence: wayland
Change-Id: I368f48fb1f5e3b7e81bdb38b5f498373be4455ae