### PR TITLE
End the start queue when startid is not used

### DIFF
--- a/src/global.h
+++ b/src/global.h
@@ -93,6 +93,7 @@ DEFINE_CONST_CHAR(clearNativeSettings);
 DEFINE_CONST_CHAR(setWMClassName);
 DEFINE_CONST_CHAR(splitWindowOnScreen);
 DEFINE_CONST_CHAR(supportForSplittingWindow);
+DEFINE_CONST_CHAR(sendEndStartupNotifition);
 
 // others
 DEFINE_CONST_CHAR(WmWindowTypes);

--- a/xcb/dplatformintegration.h
+++ b/xcb/dplatformintegration.h
@@ -83,6 +83,8 @@ private:
     DXcbXSettings *xSettings(bool onlyExists = false) const;
     static DXcbXSettings *xSettings(QXcbConnection *connection);
 
+    static void sendEndStartupNotifition();
+
 private:
     XcbNativeEventFilter *m_eventFilter = Q_NULLPTR;
     static DXcbXSettings *m_xsettings;

--- a/xcb/dplatformnativeinterfacehook.cpp
+++ b/xcb/dplatformnativeinterfacehook.cpp
@@ -76,7 +76,8 @@ static QFunctionPointer getFunction(const QByteArray &function)
         {clearNativeSettings, reinterpret_cast<QFunctionPointer>(&DPlatformIntegration::clearNativeSettings)},
         {setWMClassName, reinterpret_cast<QFunctionPointer>(&DPlatformIntegration::setWMClassName)},
         {splitWindowOnScreen, reinterpret_cast<QFunctionPointer>(&Utility::splitWindowOnScreen)},
-        {supportForSplittingWindow, reinterpret_cast<QFunctionPointer>(&Utility::supportForSplittingWindow)}
+        {supportForSplittingWindow, reinterpret_cast<QFunctionPointer>(&Utility::supportForSplittingWindow),},
+        {sendEndStartupNotifition, reinterpret_cast<QFunctionPointer>(&DPlatformIntegration::sendEndStartupNotifition),}
     };
 
     return functionCache.value(function);


### PR DESCRIPTION
Consider some singletons, or applications that start another program.
They generally don't show windows. There is no end to the start queue,
and the startid exposed by QPA in Qt indicates this type of application
processing. It is now handled uniformly in the platform plugin dxcb.

It is worth noting that this type of application needs to ensure that the
 Application object is released when it exits.

Log: Fixed some singletons not ending the startup queue