### PR TITLE
chore: 去掉使用std::bind的方式hook

### DIFF
--- a/wayland/dwayland/dnotitlebarwindowhelper_wl.cpp
+++ b/wayland/dwayland/dnotitlebarwindowhelper_wl.cpp
@@ -146,16 +146,18 @@ void DNoTitlebarWlWindowHelper::updateEnableSystemMoveFromProperty()
     m_enableSystemMove = !v.isValid() || v.toBool();
 
     if (m_enableSystemMove) {
-        using namespace std::placeholders;
-        auto hook = std::bind(&DNoTitlebarWlWindowHelper::windowEvent, _1, _2, this);
-        HookOverride(m_window, &QWindow::event, hook);
+        HookOverride(m_window, &QWindow::event, &DNoTitlebarWlWindowHelper::windowEvent);
     } else if (VtableHook::hasVtable(m_window)) {
         HookReset(m_window, &QWindow::event);
     }
 }
 
-bool DNoTitlebarWlWindowHelper::windowEvent(QWindow *w, QEvent *event, DNoTitlebarWlWindowHelper *self)
+bool DNoTitlebarWlWindowHelper::windowEvent(QWindow *w, QEvent *event)
 {
+    DNoTitlebarWlWindowHelper *self = mapped.value(w);
+
+    if (!self)
+        return VtableHook::callOriginalFun(w, &QWindow::event, event);
     // m_window 的 event 被 override 以后，在 windowEvent 里面获取到的 this 就成 m_window 了，
     // 而不是 DNoTitlebarWlWindowHelper，所以此处 windowEvent 改为 static 并传 self 进来
     {

--- a/wayland/dwayland/dnotitlebarwindowhelper_wl.h
+++ b/wayland/dwayland/dnotitlebarwindowhelper_wl.h
@@ -49,7 +49,7 @@ private slots:
     Q_SLOT void updateEnableSystemMoveFromProperty();
 
 private:
-    static bool windowEvent(QWindow *w, QEvent *event, DNoTitlebarWlWindowHelper *self);
+    static bool windowEvent(QWindow *w, QEvent *event);
     bool isEnableSystemMove();
     static void startMoveWindow(QWindow *window);
 


### PR DESCRIPTION
std::bind 的方式会打印很多警告日志。

Log:
Influence: logs
Change-Id: I958ccc76ba9b91496cdeef1ce65c51c9b54ea07b