### PR TITLE
chore: functionCache数据初始化时多了个逗号

### DIFF
--- a/xcb/dplatformnativeinterfacehook.cpp
+++ b/xcb/dplatformnativeinterfacehook.cpp
@@ -76,8 +76,8 @@ static QFunctionPointer getFunction(const QByteArray &function)
         {clearNativeSettings, reinterpret_cast<QFunctionPointer>(&DPlatformIntegration::clearNativeSettings)},
         {setWMClassName, reinterpret_cast<QFunctionPointer>(&DPlatformIntegration::setWMClassName)},
         {splitWindowOnScreen, reinterpret_cast<QFunctionPointer>(&Utility::splitWindowOnScreen)},
-        {supportForSplittingWindow, reinterpret_cast<QFunctionPointer>(&Utility::supportForSplittingWindow),},
-        {sendEndStartupNotifition, reinterpret_cast<QFunctionPointer>(&DPlatformIntegration::sendEndStartupNotifition),}
+        {supportForSplittingWindow, reinterpret_cast<QFunctionPointer>(&Utility::supportForSplittingWindow)},
+        {sendEndStartupNotifition, reinterpret_cast<QFunctionPointer>(&DPlatformIntegration::sendEndStartupNotifition)}
     };
 
     return functionCache.value(function);


### PR DESCRIPTION
functionCache数据初始化supportForSplittingWindow
和sendEndStartupNotifition多了个逗号

Log: 
Influence: none
Change-Id: I8c991137a08a519e8b56a16a45ec6602bd1c73b0