### PR TITLE
fix: supportForSplittingWindow return error

### DIFF
--- a/wayland/dwayland/dnotitlebarwindowhelper_wl.cpp
+++ b/wayland/dwayland/dnotitlebarwindowhelper_wl.cpp
@@ -106,6 +106,16 @@ void DNoTitlebarWlWindowHelper::setWindowProperty(QWindow *window, const char *n
     }
 }
 
+void DNoTitlebarWlWindowHelper::requestByWindowProperty(QWindow *window, const char *name)
+{
+    if (window && window->handle()) {
+        QtWaylandClient::QWaylandWindow *wl_window = static_cast<QtWaylandClient::QWaylandWindow *>(window->handle());
+
+        if (wl_window && wl_window->shellSurface())
+            wl_window->sendProperty(name, QVariant());
+    }
+}
+
 void DNoTitlebarWlWindowHelper::popupSystemWindowMenu(quintptr wid)
 {
     QWindow *window = fromQtWinId(wid);

--- a/wayland/dwayland/dnotitlebarwindowhelper_wl.h
+++ b/wayland/dwayland/dnotitlebarwindowhelper_wl.h
@@ -26,6 +26,7 @@ public:
     ~DNoTitlebarWlWindowHelper();
 
     static void setWindowProperty(QWindow *window, const char *name, const QVariant &value);
+    static void requestByWindowProperty(QWindow *window, const char *name);
     static void popupSystemWindowMenu(quintptr wid);
 
 private slots:

--- a/wayland/dwayland/dwaylandinterfacehook.cpp
+++ b/wayland/dwayland/dwaylandinterfacehook.cpp
@@ -171,7 +171,7 @@ bool DWaylandInterfaceHook::supportForSplittingWindow(WId wid)
     QWindow *window = fromQtWinId(wid);
     if(!window || !window->handle())
         return false;
-    DNoTitlebarWlWindowHelper::setWindowProperty(window, ::supportForSplittingWindow, false);
+    DNoTitlebarWlWindowHelper::requestByWindowProperty(window, ::supportForSplittingWindow);
     return window->property(::supportForSplittingWindow).toBool();
 }
 


### PR DESCRIPTION
  it is error when returned value of dde_shell_surface->isSplitable()
has changed, because we need to request a status from kwin instead of window's property, so we shouldn't compare old value and setted value.

Log: 是否分屏请求状态错误
Bug: https://pms.uniontech.com/bug-view-137573.html
Influence: 分屏菜单是否弹出
Change-Id: I3dfb9da4972fc7b851e4141e68cc9f646955d4ab