### PR TITLE
fix: 修复设置任务栏跟随主屏，切换显示模式时，概率性出现任务栏不在主屏的问题

### DIFF
--- a/wayland/dwayland/dwaylandintegration.cpp
+++ b/wayland/dwayland/dwaylandintegration.cpp
@@ -190,6 +190,10 @@ void DWaylandIntegration::initialize()
     // 处理主屏设置，并监听xsettings的信号用于更新
     onPrimaryScreenChanged(nullptr, XSETTINGS_PRIMARY_MONITOR_NAME, QVariant(), reinterpret_cast<void*>(XSettingType::Gdk_PrimaryMonitorName));
     dXSettings->globalSettings()->registerCallbackForProperty(XSETTINGS_PRIMARY_MONITOR_NAME, onPrimaryScreenChanged, reinterpret_cast<void*>(XSettingType::Gdk_PrimaryMonitorName));
+    // qt屏幕添加信号可能晚于xsetting，当设置主屏时，屏幕还未添加，这里监听qt屏幕添加信号，避免主屏设置不对
+    QObject::connect(qApp, &QGuiApplication::screenAdded, [] {
+        onPrimaryScreenChanged(nullptr, XSETTINGS_PRIMARY_MONITOR_NAME, QVariant(), reinterpret_cast<void*>(XSettingType::Gdk_PrimaryMonitorName));
+    }
 }
 
 QStringList DWaylandIntegration::themeNames() const


### PR DESCRIPTION
qt屏幕添加信号可能晚于xsetting，当设置主屏时，屏幕还未添加，通过监听qt屏幕添加信号，避免主屏设置不对

Log: 修复设置任务栏跟随主屏，切换显示模式时，概率性出现任务栏不在主屏的问题
Influence: 主屏幕设置
Bug: https://pms.uniontech.com/bug-view-159837.html