### PR TITLE
fix: 桌面文件重命名焦点丢失

### DIFF
--- a/xcb/windoweventhook.h
+++ b/xcb/windoweventhook.h
@@ -31,9 +31,6 @@ public:
 #else
     static bool windowEvent(QXcbWindow *window, QEvent *event);
 #endif
-
-private:
-    static bool relayFocusToModalWindow(QWindow *w, QXcbConnection *connection);
 };
 
 DPP_END_NAMESPACE


### PR DESCRIPTION
Qt 修复焦点问题后插件中 hook focusInEvent 的地方微调

Bug: https://pms.uniontech.com/bug-view-165587.html,https://pms.uniontech.com/bug-view-164477.html
Log: 桌面重命名焦点问题
Change-Id: Ic21d78844cb65743e185b716e9218e9dc152dbcf