### PR TITLE
fix: shotcuts show in context menu

### DIFF
--- a/wayland/dwayland/dwaylandintegration.cpp
+++ b/wayland/dwayland/dwaylandintegration.cpp
@@ -220,6 +220,8 @@ QVariant DWaylandIntegration::styleHint(QPlatformIntegration::StyleHint hint) co
     case MouseDoubleClickInterval:
         GET_VALID_XSETTINGS(XSETTINGS_DOUBLE_CLICK_TIME);
         break;
+    case ShowShortcutsInContextMenus:
+        return false;
     default:
         break;
     }

--- a/xcb/dplatformintegration.cpp
+++ b/xcb/dplatformintegration.cpp
@@ -536,6 +536,8 @@ QVariant DPlatformIntegration::styleHint(QPlatformIntegration::StyleHint hint) c
     case MouseDoubleClickInterval:
         GET_VALID_XSETTINGS(XSETTINGS_DOUBLE_CLICK_TIME);
         break;
+    case ShowShortcutsInContextMenus:
+        return false;
     default:
         break;
     }


### PR DESCRIPTION
Don't show shortcuts in context menu
QDeepinTheme::themeHint(ShowShortcutsInContextMenus) return false not work anymore see https://codereview.qt-project.org/c/qt/qtbase/+/351295

Bug: https://pms.uniontech.com/bug-view-167667.html
Log: Don't Show Shortcuts In Context Menus
Change-Id: Ib290a2a51e2bfd3e14e95c12d660812ef82bf36c