### PR TITLE
fix: wayland下最小化魔灯效果显示异常

### DIFF
--- a/wayland/wayland-shell/dwaylandshellmanager.h
+++ b/wayland/wayland-shell/dwaylandshellmanager.h
@@ -30,6 +30,7 @@
 #include <KWayland/Client/blur.h>
 #include <KWayland/Client/region.h>
 #include <KWayland/Client/surface.h>
+#include <KWayland/Client/plasmawindowmanagement.h>
 #else
 #include <DWayland/Client/registry.h>
 #include <DWayland/Client/plasmashell.h>
@@ -43,6 +44,7 @@
 #include <DWayland/Client/blur.h>
 #include <DWayland/Client/region.h>
 #include <DWayland/Client/surface.h>
+#include <DWayland/Client/plasmawindowmanagement.h>
 #endif
 
 #include <QGuiApplication>
@@ -91,6 +93,7 @@ public:
     static void createBlurManager(quint32 name, quint32 version);
     static void createCompositor(quint32 name, quint32 version);
     static void createSurface();
+    static void createPlasmaWindowManagement(KWayland::Client::Registry *registry, quint32 name, quint32 version);
     static void handleGeometryChange(QWaylandWindow *window);
     static void handleWindowStateChanged(QWaylandWindow *window);
     static void setWindowStaysOnTop(QWaylandShellSurface *surface, const bool state);
@@ -98,6 +101,7 @@ public:
     static void setCursorPoint(QPointF pos);
     static void setEnableBlurWidow(QWaylandWindow *wlWindow, const QVariant &value);
     static void updateWindowBlurAreasForWM(QWaylandWindow *wlWindow, const QString &name, const QVariant &value);
+    static void setDockAppItemMinimizedGeometry(QWaylandShellSurface *surface, const QVariant var);
 
 private:
     // 用于记录设置过以_DWAYALND_开头的属性，当kwyalnd_shell对象创建以后要使这些属性生效

--- a/wayland/wayland-shell/main.cpp
+++ b/wayland/wayland-shell/main.cpp
@@ -112,6 +112,10 @@ QWaylandShellIntegration *QKWaylandShellIntegrationPlugin::create(const QString 
         DWaylandShellManager::createSurface();
     });
 
+    connect(registry, &KWayland::Client::Registry::plasmaWindowManagementAnnounced, [registry](quint32 name, quint32 version) {
+        DWaylandShellManager::createPlasmaWindowManagement(registry, name, version);
+    });
+
     wl_display *wlDisplay = reinterpret_cast<wl_display*>(platformNativeDisplay);
 
     registry->create(wlDisplay);


### PR DESCRIPTION
在任务栏发送dock-appitem-geometry过来时，调用wayland协议的接口去设置应用的窗口最小化位置

Log: 修复wayland下最小化魔灯效果显示异常的问题
Bug: https://pms.uniontech.com/bug-view-111637.html
Influence: wayland下应用窗口最小化显示效果
Change-Id: Ic53215f2f18f8f2502c7ef16d9aafe7cbb7da326