### PR TITLE
Allow specify include path of qtxcb private headers

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -28,7 +28,7 @@ prepare() {
 
 build() {
   cd $deepin_source_name
-  qmake-qt5 PREFIX=/usr
+  qmake-qt5 PREFIX=/usr QT_XCB_PRIVATE_INCLUDE=/usr/include/qtxcb-private
   make
 }
 

--- a/xcb/linux.pri
+++ b/xcb/linux.pri
@@ -91,7 +91,9 @@ contains(QT_CONFIG, xcb-qt) {
     DEFINES += XCB_USE_RENDER
 }
 
-exists($$PWD/libqt5xcbqpa-dev/$$QT_VERSION) {
+!isEmpty(QT_XCB_PRIVATE_INCLUDE) {
+    INCLUDEPATH += $$QT_XCB_PRIVATE_INCLUDE
+} else:exists($$PWD/libqt5xcbqpa-dev/$$QT_VERSION) {
     INCLUDEPATH += $$PWD/libqt5xcbqpa-dev/$$QT_VERSION
 } else:exists($$[QT_INSTALL_HEADERS]/QtXcb/$$[QT_VERSION]) {
     INCLUDEPATH += $$[QT_INSTALL_HEADERS]/QtXcb/$$[QT_VERSION]/QtXcb/private


### PR DESCRIPTION
Add QT_XCB_PRIVATE_INCLUDE option in qmake build config file. You can set it for the qmake command, if its value is not empty, will using it on build and ignore the libqt5xcbqpa-dev/* files in project.