### PR TITLE
chore: load dxcb if XDG_CURRENT_DESKTOP set to DDE

### DIFF
--- a/xcb/main.cpp
+++ b/xcb/main.cpp
@@ -29,7 +29,8 @@ QPlatformIntegration* DPlatformIntegrationPlugin::create(const QString& system, 
         loadDXcb = false;
     } else if (system == "dxcb") {
         loadDXcb = true;
-    } else if (QString(qgetenv("XDG_CURRENT_DESKTOP")).toLower().startsWith("deepin")) {
+    } else if (QString(qgetenv("XDG_CURRENT_DESKTOP")).toLower().startsWith("deepin") ||
+               (qgetenv("XDG_CURRENT_DESKTOP") == QByteArrayLiteral("DDE"))) {
         loadDXcb = true;
     }
 


### PR DESCRIPTION
当桌面环境名称为 DDE 时，载入 dxcb 插件。

相关：

- https://github.com/linuxdeepin/dde-session/pull/7
- https://github.com/linuxdeepin/developer-center/issues/3829