### PR TITLE
fix: 修复桌面启动时主屏闪变

### DIFF
--- a/wayland/dwayland/dwaylandintegration.cpp
+++ b/wayland/dwayland/dwaylandintegration.cpp
@@ -194,6 +194,9 @@ void DWaylandIntegration::initialize()
     // 增加rect的属性，保存主屏的具体坐标，不依靠其name判断(根据name查找对应的屏幕时概率性出错，根据主屏的rect确定哪一个QScreen才是主屏)
     dXSettings->globalSettings()->registerCallbackForProperty(XSETTINGS_PRIMARY_MONITOR_RECT, onPrimaryRectChanged, reinterpret_cast<void*>(XSettingType::Dde_PrimaryMonitorRect));
 
+    //初始化时应该设一次主屏，防止应用启动时主屏闪变
+    onPrimaryRectChanged(nullptr, XSETTINGS_PRIMARY_MONITOR_RECT, QVariant(), reinterpret_cast<void*>(XSettingType::Dde_PrimaryMonitorRect));
+
     QTimer *m_delayTimer = new QTimer;
     m_delayTimer->setInterval(10);
     m_delayTimer->setSingleShot(true);


### PR DESCRIPTION
当设置主屏为VGA时,登录到桌面或者重启桌面,主屏会从HDMI变到VGA,是因为DWaylandIntegration初始化时只做了连接,并没有设置主屏,因此在连接前设置一次主屏

Log: 修复桌面启动时主屏闪变
Bug: https://pms.uniontech.com/bug-view-195723.html
Influence: 主屏设置 dwayland