### PR TITLE
fix: deepin-movie's window is resized when moving the mouse beside the edge

### DIFF
--- a/xcb/windoweventhook.cpp
+++ b/xcb/windoweventhook.cpp
@@ -263,6 +263,10 @@ void WindowEventHook::handleClientMessageEvent(QXcbWindow *window, const xcb_cli
         dropData->setProperty("IsDirectSaveMode", directSaveMode);
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
+        // Drop coming from another app? Update buttons.
+        if (!drag->currentDrag())
+            QGuiApplicationPrivate::mouse_buttons = window->connection()->queryMouseButtons();
+
         QPlatformDropQtResponse response = QWindowSystemInterface::handleDrop(drag->currentWindow.data(),
                                                                             dropData, drag->currentPosition,
                                                                               supported_drop_actions,


### PR DESCRIPTION
Drag a file into the window and drop, the mouse state should be from Leftbutton to NoButton. 
But the current mouse state is always Leftbutton, which causes the window to be resized when moving the mouse beside the edge.
Update the mouse buttons' state by querying the state from xserver.
Issue: https://github.com/linuxdeepin/dtk/issues/63