### PR TITLE
chore: set the default install prefix of cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,10 @@ project(qt5platform-plugins
     LANGUAGES CXX C
 )
 
+if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    set(CMAKE_INSTALL_PREFIX /usr)
+endif ()
+
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 


### PR DESCRIPTION
set the default install prefix to /usr

Log: set the default install prefix of cmake