### PR TITLE
fix: can't find qeventpoint_p.h in qt5

### DIFF
--- a/xcb/dplatformwindowhelper.cpp
+++ b/xcb/dplatformwindowhelper.cpp
@@ -20,7 +20,9 @@
 
 #include <private/qwindow_p.h>
 #include <private/qguiapplication_p.h>
+#if QT_VERSION >= QT_VERSION_CHECK(6, 4, 2)
 #include <private/qeventpoint_p.h>
+#endif
 #include <qpa/qplatformcursor.h>
 
 #include <QPainterPath>


### PR DESCRIPTION
add qt version macro to control the file

Log: can't find qeventpoint_p.h in qt5