### PR TITLE
fix: Crashed when received xcb event in debug wayland plugin

### DIFF
--- a/src/dnativesettings.h
+++ b/src/dnativesettings.h
@@ -5,12 +5,13 @@
 #ifndef DNATIVESETTINGS_H
 #define DNATIVESETTINGS_H
 
-#include "global.h"
-
-#include <QSet>
 #define protected public
 #include <private/qobject_p.h>
 #undef protected
+
+#include "global.h"
+
+#include <QSet>
 #include <private/qmetaobjectbuilder_p.h>
 
 DPP_BEGIN_NAMESPACE

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -17,3 +17,24 @@ QWindow * fromQtWinId(WId id) {
     }
     return window;
 };
+
+DPP_BEGIN_NAMESPACE
+
+RunInThreadProxy::RunInThreadProxy(QObject *parent)
+    : QObject(parent)
+{
+}
+
+void RunInThreadProxy::proxyCall(FunctionType func)
+{
+    QObject *receiver = parent();
+    if (!receiver)
+        receiver = qApp;
+
+    QObject scope;
+    connect(&scope, &QObject::destroyed, receiver, [func]() {
+        (func)();
+    }, Qt::QueuedConnection);
+}
+
+DPP_END_NAMESPACE

--- a/src/global.h
+++ b/src/global.h
@@ -6,6 +6,7 @@
 #define GLOBAL_H
 
 #include <qwindowdefs.h>
+#include <QObject>
 
 #define MOUSE_MARGINS 10
 
@@ -112,4 +113,16 @@ enum DeviceType {
 class QWindow;
 QWindow * fromQtWinId(WId id);
 
+DPP_BEGIN_NAMESPACE
+
+class RunInThreadProxy : public QObject
+{
+    Q_OBJECT
+public:
+    using FunctionType = std::function<void()>;
+    explicit RunInThreadProxy(QObject *parent = nullptr);
+    void proxyCall(FunctionType func);
+
+};
+DPP_END_NAMESPACE
 #endif // GLOBAL_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 project(ut-platformplugins)
 
-find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Gui Widgets Test)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Gui Widgets Concurrent Test)
 find_package(GTest REQUIRED)
 if(${QT_VERSION_MAJOR} STREQUAL "5")
     find_package(Qt5 REQUIRED COMPONENTS XcbQpa X11Extras EdidSupport XkbCommonSupport)
@@ -44,6 +44,7 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
     Qt${QT_VERSION_MAJOR}::Gui
     Qt${QT_VERSION_MAJOR}::GuiPrivate
     Qt${QT_VERSION_MAJOR}::Widgets
+    Qt${QT_VERSION_MAJOR}::Concurrent
     Qt${QT_VERSION_MAJOR}::Test
     GTest::GTest
     gmock

--- a/tests/src/ut_global.cpp
+++ b/tests/src/ut_global.cpp
@@ -3,7 +3,10 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
 #include <gtest/gtest.h>
+#include <QThread>
 #include <QWindow>
+#include <QtConcurrent>
+#include <QTest>
 
 #include "global.h"
 
@@ -33,4 +36,22 @@ TEST_F(TGlobal, fromQtWinId)
     ASSERT_EQ(w, window);
 }
 
+
+TEST(TRunInThreadProxy, callInThread)
+{
+    DPP_USE_NAMESPACE;
+
+    QThread *calledThread = nullptr;
+
+    auto feature = QtConcurrent::run([&calledThread]() {
+        RunInThreadProxy proxy;
+        proxy.proxyCall([&calledThread]() {
+            calledThread = QThread::currentThread();
+        });
+    });
+    feature.waitForFinished();
+    QCoreApplication::processEvents();
+
+    ASSERT_EQ(qApp->thread(), calledThread);
+}
 


### PR DESCRIPTION
  `setProperty` will call sendEvent, and the `handle->m_base`
is construct in main thread but called in DXcbEventFilter's thread, It caused Q_ASSERT failed because `sendEvent` in different thread.
  We handle xcb event in main thread.