### PR TITLE
fix: the autoStarted app crashed when dragging it

### DIFF
--- a/xcb/dplatformwindowhelper.cpp
+++ b/xcb/dplatformwindowhelper.cpp
@@ -702,18 +702,19 @@ bool DPlatformWindowHelper::eventFilter(QObject *watched, QEvent *event)
                 DQMouseEvent *e = static_cast<DQMouseEvent*>(event);
 
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-                e->l = e->w = m_nativeWindow->window()->mapFromGlobal(e->globalPos());
-                qApp->sendEvent(m_nativeWindow->window(), e);
+                e->l = e->w = m_frameWindow->mapFromGlobal(e->globalPos());
+                QGuiApplicationPrivate::setMouseEventSource(e, Qt::MouseEventSynthesizedByQt);
+                m_frameWindow->mouseMoveEvent(e);
 #elif QT_VERSION <= QT_VERSION_CHECK(6, 2, 4)
                 QScopedPointer<QMutableSinglePointEvent> mevent(QMutableSinglePointEvent::from(e->clone()));
-                mevent->mutablePoint().setPosition(m_nativeWindow->window()->mapFromGlobal(e->globalPosition()));
-                mevent->mutablePoint().setScenePosition(m_nativeWindow->window()->mapFromGlobal(e->globalPosition()));
-                qApp->sendEvent(m_nativeWindow->window(), mevent.data());
+                mevent->mutablePoint().setPosition(m_frameWindow->mapFromGlobal(e->globalPosition()));
+                mevent->mutablePoint().setScenePosition(m_frameWindow->mapFromGlobal(e->globalPosition()));
+                qApp->sendEvent(m_frameWindow, mevent.data());
 #else
                 QScopedPointer<QMutableSinglePointEvent> mevent(QMutableSinglePointEvent::from(e->clone()));
-                QMutableEventPoint::setPosition(mevent->point(0), m_nativeWindow->window()->mapFromGlobal(e->globalPosition()));
-                QMutableEventPoint::setScenePosition(mevent->point(0), m_nativeWindow->window()->mapFromGlobal(e->globalPosition()));
-                qApp->sendEvent(m_nativeWindow->window(), mevent.data());
+                QMutableEventPoint::setPosition(mevent->point(0), m_frameWindow->mapFromGlobal(e->globalPosition()));
+                QMutableEventPoint::setScenePosition(mevent->point(0), m_frameWindow->mapFromGlobal(e->globalPosition()));
+                qApp->sendEvent(m_frameWindow, mevent.data());
 #endif
                 return true;
             }


### PR DESCRIPTION
typed wrong window type when adapting to Qt6

Log: fix the autoStarted app crashed when dragging it