### PR TITLE
fix: use ECM to help DWayland find Wayland

### DIFF
--- a/wayland/wayland-shell/wayland-shell.cmake
+++ b/wayland/wayland-shell/wayland-shell.cmake
@@ -2,6 +2,9 @@
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
+find_package(ECM REQUIRED 1.0.0)
+set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH} ${CMAKE_MODULE_PATH})
+
 find_package(DWayland)
 if(DWayland_FOUND)
     add_definitions(-DD_DEEPIN_IS_DWAYLAND)


### PR DESCRIPTION
DWayland uses ECM's module to find Wayland and everything using it will fail to find Wayland without ECM.

Fixes building on Arch.