### PR TITLE
fix: 修复远程协助关于对话框透明

### DIFF
--- a/xcb/dplatformintegration.cpp
+++ b/xcb/dplatformintegration.cpp
@@ -144,14 +144,6 @@ void DPlatformIntegration::setWindowProperty(QWindow *window, const char *name, 
 
 bool DPlatformIntegration::enableDxcb(QWindow *window)
 {
-    static bool xwayland = QByteArrayLiteral("wayland") == qgetenv("XDG_SESSION_TYPE")
-            && !qEnvironmentVariableIsEmpty("WAYLAND_DISPLAY");
-
-    if (xwayland) {
-        // for xwayland
-        return false;
-    }
-
     qDebug() << __FUNCTION__ << window << window->type() << window->parent();
 
     if (window->type() == Qt::Desktop)


### PR DESCRIPTION
xcb插件设置了wayland下运行xcb应用不支持dxcb

Log: 
Influence: 所有在wayland下运行的x窗口