### PR TITLE
fix: 修复当窗口标题栏跟dock栏有重叠时，分屏菜单不显示

### DIFF
--- a/wayland/dwayland/dnotitlebarwindowhelper_wl.cpp
+++ b/wayland/dwayland/dnotitlebarwindowhelper_wl.cpp
@@ -26,6 +26,8 @@
 
 #include <private/qguiapplication_p.h>
 
+extern QWidget *qt_button_down;
+
 DPP_BEGIN_NAMESPACE
 
 QHash<const QWindow*, DNoTitlebarWlWindowHelper*> DNoTitlebarWlWindowHelper::mapped;
@@ -201,6 +203,10 @@ bool DNoTitlebarWlWindowHelper::windowEvent(QWindow *w, QEvent *event)
 
             event->accept();
             startMoveWindow(w);
+
+            if (qt_button_down) {
+                qt_button_down = nullptr;
+            }
         }
     }
 

--- a/xcb/dnotitlebarwindowhelper.cpp
+++ b/xcb/dnotitlebarwindowhelper.cpp
@@ -23,6 +23,8 @@
 #define _DEEPIN_SCISSOR_WINDOW "_DEEPIN_SCISSOR_WINDOW"
 Q_DECLARE_METATYPE(QPainterPath)
 
+extern QWidget *qt_button_down;
+
 DPP_BEGIN_NAMESPACE
 
 QHash<const QWindow*, DNoTitlebarWindowHelper*> DNoTitlebarWindowHelper::mapped;
@@ -503,6 +505,10 @@ bool DNoTitlebarWindowHelper::windowEvent(QEvent *event)
 
             event->accept();
             startMoveWindow(winId);
+
+            if (qt_button_down) {
+                qt_button_down = nullptr;
+            }
         }
     }
 


### PR DESCRIPTION
from https://github.com/linuxdeepin/dtkwidget/pull/200 通过窗口管理器移动窗口时，鼠标按下并移动，之后事件由窗管接管
移动结束后，应用无法收到鼠标释放的事件，导致没有刷新全局的 qt_button_down
此时 sendMouseEvent 无法走到 dispatchEnterLeave 即没有 enter/leave 事件触发，也就没有了 hover 状态。收到 mouse move 且没有鼠标按下的状态时 置空 qt_button_down

Log: 修复当窗口标题栏跟dock栏有重叠时，分屏菜单不显示
Bug: https://pms.uniontech.com/bug-view-157629.html
Influence: 所有使用DTK标题栏的窗口