### PR TITLE
refact: move compile generated plugins to build directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
 else ()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Ofast")
 endif ()
-set(LIBRARY_OUTPUT_PATH ${CMAKE_SOURCE_DIR}/bin/plugins/platforms)
+set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/plugins/platforms)
 
 add_subdirectory(xcb)
 if("${PROJECT_VERSION_MAJOR}" STREQUAL "5")

--- a/wayland/dwayland/CMakeLists.txt
+++ b/wayland/dwayland/CMakeLists.txt
@@ -17,8 +17,6 @@ add_definitions(-DQT5DWAYLANDPLUGIN_LIBRARY -DQT_DEPRECATED_WARNINGS)
 
 include(${CMAKE_CURRENT_LIST_DIR}/dwayland.cmake)
 
-set(LIBRARY_OUTPUT_PATH ${CMAKE_SOURCE_DIR}/bin/plugins/platforms)
-
 add_library(${PROJECT_NAME} MODULE main.cpp ${wayland_SRC})
 
 target_compile_definitions(${PROJECT_NAME} 

--- a/wayland/wayland-shell/CMakeLists.txt
+++ b/wayland/wayland-shell/CMakeLists.txt
@@ -36,9 +36,10 @@ else()
     message(WARNING "QtWayland version incompatible")
 endif()
 
-set(LIBRARY_OUTPUT_PATH ${CMAKE_SOURCE_DIR}/bin/plugins/wayland-shell-integration)
-
 add_library(${PROJECT_NAME} MODULE main.cpp ${GLOBAL_SOURCES} ${GLOBAL_HEADERS})
+set_target_properties(${PROJECT_NAME} PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/plugins/wayland-shell-integration
+)
 
 target_compile_definitions(${PROJECT_NAME}
     PRIVATE


### PR DESCRIPTION
  Moving compile generated plugins from source directory to
build directory.
