### PR TITLE
fix: DPlatformTheme::property not work

### DIFF
--- a/src/dnativesettings.cpp
+++ b/src/dnativesettings.cpp
@@ -415,7 +415,7 @@ int DNativeSettings::metaCall(QMetaObject::Call _c, int _id, void ** _a)
         const int index = p.propertyIndex();
         // 对于本地属性，此处应该从m_settings中读写
         if (Q_LIKELY(index != m_flagPropertyIndex && index != m_allKeysPropertyIndex
-                     && index >= m_firstProperty)) {
+                     && index >= m_firstProperty + m_propertyCount)) {
             switch (_c) {
             case QMetaObject::ReadProperty:
                 *reinterpret_cast<QVariant*>(_a[1]) = m_settings->setting(p.name());

--- a/src/dnativesettings.cpp
+++ b/src/dnativesettings.cpp
@@ -146,7 +146,11 @@ void DNativeSettings::init(const QMetaObject *metaObject)
 
         QMetaPropertyBuilder op;
 
-        switch (mp.type()) {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+        switch (mp.metaType()) {
+#else
+        switch (static_cast<int>(mp.type())) {
+#endif
         case QMetaType::QByteArray:
         case QMetaType::QString:
         case QMetaType::QColor:


### PR DESCRIPTION
buildNativeSettings 之后 metaobject 被替换了
不会走原来的 read 方法了。
这里如果读取时 xsettings 中如果没有 fallback 到
base 对象的 read 方法

Issue: https://github.com/linuxdeepin/dtk/issues/101