### PR TITLE
fix: stack overflow with property/setProperty

### DIFF
--- a/xcb/dnotitlebarwindowhelper.cpp
+++ b/xcb/dnotitlebarwindowhelper.cpp
@@ -39,7 +39,8 @@ DNoTitlebarWindowHelper::DNoTitlebarWindowHelper(QWindow *window, quint32 window
         window->setFlags(window->flags() & ~Qt::FramelessWindowHint);
 
     mapped[window] = this;
-    m_nativeSettingsValid = DPlatformIntegration::buildNativeSettings(this, windowID);
+    m_settingsProxy = new QObject(this);
+    m_nativeSettingsValid = DPlatformIntegration::buildNativeSettings(m_settingsProxy, windowID);
     Q_ASSERT(m_nativeSettingsValid);
 
     // 本地设置无效时不可更新窗口属性，否则会导致setProperty函数被循环调用
@@ -208,12 +209,26 @@ QMarginsF DNoTitlebarWindowHelper::mouseInputAreaMargins() const
     return takeMargins(property("mouseInputAreaMargins"), QMarginsF(0, 0, 0, 0));
 }
 
+QVariant DNoTitlebarWindowHelper::property(const char *name) const
+{
+    return m_settingsProxy ? m_settingsProxy->property(name) : QVariant();
+}
+
+bool DNoTitlebarWindowHelper::setProperty(const char *name, const QVariant &value)
+{
+    return m_settingsProxy ? m_settingsProxy->setProperty(name, value) : false;
+}
+
 void DNoTitlebarWindowHelper::resetProperty(const QByteArray &property)
 {
-    int index = metaObject()->indexOfProperty(property.constData());
+    if (!m_settingsProxy)
+        return;
+
+    const QMetaObject *metaObject = m_settingsProxy->metaObject();
+    int index = metaObject->indexOfProperty(property.constData());
 
     if (index >= 0) {
-        metaObject()->property(index).reset(this);
+        metaObject->property(index).reset(this);
     }
 }
 

--- a/xcb/dnotitlebarwindowhelper.h
+++ b/xcb/dnotitlebarwindowhelper.h
@@ -50,6 +50,8 @@ public:
     QColor shadowColor() const;
     QMarginsF mouseInputAreaMargins() const;
 
+    QVariant property(const char *name) const;
+    bool setProperty(const char *name, const QVariant &value);
     void resetProperty(const QByteArray &property);
     void setTheme(const QString &theme);
     void setWindowRadius(const QPointF &windowRadius);
@@ -113,7 +115,7 @@ private:
     bool m_enableSystemMove = true;
     bool m_enableBlurWindow = false;
     bool m_autoInputMaskByClipPath = false;
-    DNativeSettings *m_settings;
+    QObject *m_settingsProxy = nullptr;
 
     static QHash<const QWindow*, DNoTitlebarWindowHelper*> mapped;
 


### PR DESCRIPTION
commit 1272c423 引入base 的 property/setProperty 会走自己的 read/write 方法，这里直接在 read/write 方法中调用 property/setProperty 会导致递归调用最终栈溢出崩溃

解决办法： 加一个 nativesettings 代理，并且通过同名 property/setProperty 函数隐藏父类的实现