### PR TITLE
fix: blurWindow not update (bump to 5.6.22)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-qt5platform-plugins (5.6.22) unstable; urgency=medium
+
+  * fix #7057
+
+ -- Mike Chen <chenke@deepin.org>  Thu, 25 Jan 2024 16:14:18 +0800
+
 dde-qt5platform-plugins (5.6.21) unstable; urgency=medium
 
   * release 5.6.21

--- a/xcb/dxcbwmsupport.cpp
+++ b/xcb/dxcbwmsupport.cpp
@@ -154,7 +154,7 @@ void DXcbWMSupport::updateHasBlurWindow()
     bool hasBlurWindow((m_isDeepinWM && isSupportedByWM(_net_wm_deepin_blur_region_rounded_atom))
                        || (m_isKwin && isContainsForRootWindow(_kde_net_wm_blur_rehind_region_atom)));
     // 当窗口visual不支持alpha通道时，也等价于不支持窗口背景模糊
-    hasBlurWindow = hasBlurWindow && getHasWindowAlpha() && hasComposite();
+    hasBlurWindow = hasBlurWindow && getHasWindowAlpha();
 
     if (m_hasBlurWindow == hasBlurWindow)
         return;


### PR DESCRIPTION
hasComposite is not a requirement for hasBlurWindow

Issue: https://github.com/linuxdeepin/developer-center/issues/7057