### PR TITLE
fix: window border properties cannot change in real time

### DIFF
--- a/src/dnativesettings.cpp
+++ b/src/dnativesettings.cpp
@@ -87,6 +87,7 @@ bool DNativeSettings::isValid() const
     return m_settings->initialized();
 }
 
+// TODO: This class needs to add a unit test
 void DNativeSettings::init(const QMetaObject *metaObject)
 {
     m_objectBuilder.addMetaObject(metaObject);
@@ -161,18 +162,13 @@ void DNativeSettings::init(const QMetaObject *metaObject)
             break;
         default:
             // 重设属性的类型，只支持Int double color string bytearray
-            op = ob.addProperty(mp.name(), "QByteArray", mp.notifySignalIndex());
+            op = ob.addProperty(mp.name(), "QByteArray", mp.notifySignalIndex() - signal_offset);
             break;
         }
 
         if (op.isWritable()) {
             // 声明支持属性reset
             op.setResettable(true);
-        }
-
-        // 重置属性对应的信号
-        if (op.hasNotifySignal()) {
-            op.setNotifySignal(ob.method(op.notifySignal().index() - signal_offset));
         }
     }
 


### PR DESCRIPTION
QByteArray类型没减去偏移量,在最后对整体QMetaObjectBuilder减偏移量时导致普通类型都被多减了一次 (从QMetaProperty到QMetaPropertyBuilder使用addProperty会自动处理偏移量) 两种方案:
1. 如果在最后统一处理,索引应该使用mp.notifySignalIndex()而不是op.notifySignal().index()
2. 在处理QByteArray类型时减去偏移量

Log: 修复边界颜色,边框宽度,阴影颜色,偏移量等窗口属性等不能实时变化
Issue: https://github.com/linuxdeepin/developer-center/issues/8342
Influence: 边界颜色,边框宽度,阴影颜色,偏移量等窗口属性