### PR TITLE
fix: quickwindow close crashed

### DIFF
--- a/xcb/dnotitlebarwindowhelper.h
+++ b/xcb/dnotitlebarwindowhelper.h
@@ -98,7 +98,7 @@ private slots:
     Q_SLOT void updateAutoInputMaskByClipPathFromProperty();
 
 private:
-    bool windowEvent(QEvent *event);
+    virtual bool eventFilter(QObject *watched, QEvent *event) override;
     bool isEnableSystemMove(quint32 winId);
     bool updateWindowBlurAreasForWM();
     void updateWindowShape();


### PR DESCRIPTION
use eventfilter instead of vtablehook(QObject destroy crashed)

pms: Bug-290897