### PR TITLE
fix: app crashed when window destroyed in quick

### DIFF
--- a/src/vtablehook.cpp
+++ b/src/vtablehook.cpp
@@ -185,15 +185,15 @@ void VtableHook::autoCleanVtable(const void *obj)
     if (!fun)
         return;
 
-    typedef void(*Destruct)(const void*);
-    Destruct destruct = reinterpret_cast<Destruct>(fun);
-    // call origin destruct function
-    destruct(obj);
-
     if (hasVtable(obj)) {// 需要判断一下，有可能在执行析构函数时虚表已经被删除
         // clean
         clearGhostVtable(obj);
     }
+
+    typedef void(*Destruct)(const void*);
+    Destruct destruct = reinterpret_cast<Destruct>(fun);
+    // call origin destruct function
+    destruct(obj);
 }
 
 bool VtableHook::ensureVtable(const void *obj, std::function<void ()> destoryObjFun)

--- a/xcb/dnotitlebarwindowhelper.cpp
+++ b/xcb/dnotitlebarwindowhelper.cpp
@@ -81,10 +81,6 @@ DNoTitlebarWindowHelper::~DNoTitlebarWindowHelper()
 {
     g_pressPoint.remove(this);
 
-    if (VtableHook::hasVtable(m_window)) {
-        VtableHook::resetVtable(m_window);
-    }
-
     mapped.remove(qobject_cast<QWindow*>(parent()));
 
     if (m_window->handle()) { // 当本地窗口还存在时，移除设置过的窗口属性


### PR DESCRIPTION
- fix: hasVtable is incorrect when destructing
- fix: app crashed when window destroyed in quick
