### PR TITLE
fix: app crashed for DNotitebarWindowHelper

### DIFF
--- a/xcb/dnotitlebarwindowhelper.cpp
+++ b/xcb/dnotitlebarwindowhelper.cpp
@@ -81,6 +81,10 @@ DNoTitlebarWindowHelper::~DNoTitlebarWindowHelper()
 {
     g_pressPoint.remove(this);
 
+    if (VtableHook::hasVtable(m_window)) {
+        VtableHook::resetVtable(m_window);
+    }
+
     mapped.remove(qobject_cast<QWindow*>(parent()));
 
     if (m_window->handle()) { // 当本地窗口还存在时，移除设置过的窗口属性


### PR DESCRIPTION
DNotitebarWindowHelper is delete by manual instead of Window
deleted, so we need to resetVtable.

pms: BUG-368399
