### PR TITLE
fix: DNotitlebarWindowHelper can't be removed from mapped

### DIFF
--- a/wayland/dwayland/dnotitlebarwindowhelper_wl.cpp
+++ b/wayland/dwayland/dnotitlebarwindowhelper_wl.cpp
@@ -50,7 +50,7 @@ DNoTitlebarWlWindowHelper::~DNoTitlebarWlWindowHelper()
         VtableHook::resetVtable(m_window);
     }
 
-    mapped.remove(qobject_cast<QWindow*>(parent()));
+    mapped.remove(static_cast<QWindow*>(parent()));
 
     // TODO
     // if (m_window->handle()) { // 当本地窗口还存在时，移除设置过的窗口属性

--- a/xcb/dnotitlebarwindowhelper.cpp
+++ b/xcb/dnotitlebarwindowhelper.cpp
@@ -85,7 +85,7 @@ DNoTitlebarWindowHelper::~DNoTitlebarWindowHelper()
         VtableHook::resetVtable(m_window);
     }
 
-    mapped.remove(qobject_cast<QWindow*>(parent()));
+    mapped.remove(static_cast<QWindow*>(parent()));
 
     if (m_window->handle()) { // 当本地窗口还存在时，移除设置过的窗口属性
         Utility::clearWindowProperty(m_windowID, Utility::internAtom(_DEEPIN_SCISSOR_WINDOW));


### PR DESCRIPTION
qobject_cast<QWindow*>(window) is returned nullptr if window is destroyed in qt6, and we can see it on tst_QWindow::qobject_castOnDestruction() in tst_qwindow.cpp.

pms: BUG-299239