### PR TITLE
fix: ToolTip's xsettings can't work in qt6

### DIFF
--- a/xcb/dnotitlebarwindowhelper.cpp
+++ b/xcb/dnotitlebarwindowhelper.cpp
@@ -284,6 +284,11 @@ void DNoTitlebarWindowHelper::setWindowStartUpEffect(quint32 effectType)
     setProperty("windowStartUpEffect", effectType);
 }
 
+DNoTitlebarWindowHelper *DNoTitlebarWindowHelper::windowHelper(const QWindow *window)
+{
+    return mapped.value(window);
+}
+
 void DNoTitlebarWindowHelper::updateClipPathFromProperty()
 {
     const QVariant &v = m_window->property(clipPath);

--- a/xcb/dnotitlebarwindowhelper.h
+++ b/xcb/dnotitlebarwindowhelper.h
@@ -66,6 +66,8 @@ public:
     void setWindowEffect(quint32 effectScene);
     void setWindowStartUpEffect(quint32 effectType);
 
+    static DNoTitlebarWindowHelper *windowHelper(const QWindow *window);
+
 signals:
     void themeChanged();
     void windowRadiusChanged();


### PR DESCRIPTION
Window is recreated if Window's flags is Qt::ToolTip and missing
WindowStaysOnTopHint, in case, Qt will append WindowStaysOnTopHint
flag to the window in QXcbWindow::setWindowFlags, it causes
window is recreated in qt6.
We reconstruct DNoTitlebarWindowHelper to update xsettings value.
We can also add WindowStaysOnTopHint for the window.

pms: BUG-302661
