### PR TITLE
fix: adapt to qt6 for PlatformWindowHelper

### DIFF
--- a/xcb/dframewindow.cpp
+++ b/xcb/dframewindow.cpp
@@ -924,8 +924,13 @@ void DFrameWindow::updateShadow()
     update();
 
     // 阴影更新后尝试刷新内部窗口
-    if (m_contentBackingStore)
+    if (m_contentBackingStore) {
+        // Timer maybe miss killed if updateShadow is called frequently.
+        if (m_paintShadowOnContentTimerId >= 0) {
+            killTimer(m_paintShadowOnContentTimerId);
+        }
         m_paintShadowOnContentTimerId = startTimer(300, Qt::PreciseTimer);
+    }
 }
 
 void DFrameWindow::updateShadowAsync(int delaye)


### PR DESCRIPTION
Timer maybe miss killed.
MouseEvent conversion is wrong in qt6, old way will be called
recursively.
requestActivateWindow is called recurisvely in qt6.

pms: TASK-368399
