### PR TITLE
feat: enhance touch drag support for QML windows in qt6

### DIFF
--- a/xcb/dnotitlebarwindowhelper.h
+++ b/xcb/dnotitlebarwindowhelper.h
@@ -15,6 +15,9 @@
 
 QT_BEGIN_NAMESPACE
 class QWindow;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+class QPointerEvent;
+#endif
 QT_END_NAMESPACE
 
 DPP_BEGIN_NAMESPACE
@@ -104,6 +107,14 @@ private:
     bool isEnableSystemMove(quint32 winId);
     bool updateWindowBlurAreasForWM();
     void updateWindowShape();
+    
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    // 新增：QML窗口触摸拖拽处理函数 (仅Qt6)
+    bool handleTouchDragForQML(QPointerEvent *touchEvent);
+#else
+    // Qt5版本的触摸拖拽处理函数
+    bool handleTouchDragForQML(QTouchEvent *touchEvent);
+#endif
 
     void onWindowSizeChanged();
 
@@ -114,6 +125,7 @@ private:
     quint32 m_windowID;
     bool m_windowMoving = false;
     bool m_nativeSettingsValid = false;
+    bool m_isQuickWindow = false;  // 新增：缓存窗口类型判断结果
 
     QVector<Utility::BlurArea> m_blurAreaList;
     QList<QPainterPath> m_blurPathList;

--- a/xcb/utility.h
+++ b/xcb/utility.h
@@ -54,6 +54,8 @@ public:
     // 导致窗口无法移动。此处跟deepin-wm配合，使用其它方式通知窗管鼠标位置更新了
     // TODO: kwin适配udpate之后没有结束move状态，新增一个finished参数，当传入true时通知kwin结束
     static void updateMousePointForWindowMove(quint32 WId, bool finished = false);
+    // 新增：支持多屏幕的版本，接受自定义全局坐标
+    static void updateMousePointForWindowMove(quint32 WId, const QPoint &globalPos, bool finished = false);
 
     static void showWindowSystemMenu(quint32 WId, QPoint globalPos = QPoint());
     static void setFrameExtents(WId wid, const QMargins &margins);

--- a/xcb/utility_x11.cpp
+++ b/xcb/utility_x11.cpp
@@ -168,8 +168,15 @@ void Utility::cancelWindowMoveResize(quint32 WId)
 
 void Utility::updateMousePointForWindowMove(quint32 WId, bool finished/* = false*/)
 {
-    xcb_client_message_event_t xev;
+    // 获取主屏幕的光标位置并调用重载版本
     const QPoint &globalPos = qApp->primaryScreen()->handle()->cursor()->pos();
+    updateMousePointForWindowMove(WId, globalPos, finished);
+}
+
+// 新增：支持多屏幕的版本，接受自定义全局坐标
+void Utility::updateMousePointForWindowMove(quint32 WId, const QPoint &globalPos, bool finished/* = false*/)
+{
+    xcb_client_message_event_t xev;
 
     xev.response_type = XCB_CLIENT_MESSAGE;
     xev.type = internAtom("_DEEPIN_MOVE_UPDATE");


### PR DESCRIPTION
1. Added touch drag support for QQuickWindow with proper grabber state
tracking
2. Implemented multi-screen aware touch drag handling with position
validation
3. Added new Utility::updateMousePointForWindowMove overload for custom
positions
4. Improved window boundary checks using scene coordinates
5. Added debug logging for window drag operations

The changes enable proper touch-based window dragging for QML-based
applications while maintaining existing mouse drag functionality. The
implementation tracks touch grabber states to determine if QML items
have handled the touch events, and only initiates window dragging when
no QML items have claimed the touch points. The multi-screen support
ensures correct behavior across different display configurations.

feat: 增强QML窗口的触摸拖拽支持

1. 为QQuickWindow添加触摸拖拽支持，并正确跟踪grabber状态
2. 实现多屏幕感知的触摸拖拽处理，包含位置验证
3. 新增Utility::updateMousePointForWindowMove重载方法支持自定义位置
4. 使用场景坐标改进窗口边界检查
5. 添加窗口拖拽操作的调试日志

这些变更使得基于QML的应用程序能够正确支持触摸拖拽窗口，同时保留现有的鼠
标拖拽功能。实现通过跟踪触摸grabber状态来判断QML组件是否处理了触摸事件，
仅当没有QML组件处理时才启动窗口拖拽。多屏幕支持确保在不同显示配置下的正
确行为。

pms: BUG-309157
