### PR TITLE
fix: make version optional in release workflow and update rpm spec

### DIFF
--- a/.github/workflows/call-auto-release.yml
+++ b/.github/workflows/call-auto-release.yml
@@ -5,7 +5,7 @@ on:
       version:
         description: 'Release version (e.g., 1.0.0)'
         type: string
-        required: true
+        required: false
       name:
         description: 'The name of the person to release the version'
         type: string

--- a/rpm/qt5platform-plugins.spec
+++ b/rpm/qt5platform-plugins.spec
@@ -4,8 +4,8 @@
 %endif
 
 Name:           dde-qt5platform-plugins
-Version: 5.7.17
-Release: 1
+Version:        5.7.17
+Release:        1%{?dist}
 Summary:        Qt platform plugins for DDE
 License:        GPLv3
 URL:            https://github.com/linuxdeepin/deepin-desktop-schemas


### PR DESCRIPTION
1. Changed version input from required to optional in GitHub workflow to
allow more flexible release process
2. Updated rpm spec file formatting for consistency
3. Added %{?dist} macro to Release field for better compatibility with
different distributions

fix: 使版本号在发布工作流中可选并更新 rpm 规范

1. 将 GitHub 工作流中的版本输入从必选改为可选，以实现更灵活的发布流程
2. 更新 rpm 规范文件格式以提高一致性
3. 在 Release 字段中添加 %{?dist} 宏以提高与不同发行版的兼容性
