### PR TITLE
fix: add Qt6 compatibility and resolve build warnings

### DIFF
--- a/src/ddesktopinputselectioncontrol.cpp
+++ b/src/ddesktopinputselectioncontrol.cpp
@@ -475,9 +475,15 @@ bool DDesktopInputSelectionControl::eventFilter(QObject *object, QEvent *event)
             break;
 
         QTouchEvent *touchEvent = static_cast<QTouchEvent *>(event);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        const auto& tpList = touchEvent->points();
+        const auto& tp = tpList.first();
+        QPointF touchPos = tp.lastPosition();
+#else
         QList<QTouchEvent::TouchPoint> tpList = touchEvent->touchPoints();
         QTouchEvent::TouchPoint tp = tpList.first();
         QPointF touchPos = tp.lastPos();
+#endif
 
         // 有效点击位置
         QRectF effectiveRect = anchorRectangle();
@@ -511,7 +517,11 @@ bool DDesktopInputSelectionControl::eventFilter(QObject *object, QEvent *event)
             break;
 
         QMouseEvent *me = static_cast<QMouseEvent *>(event);
-        const QPoint mousePos = me->screenPos().toPoint();
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        QPoint mousePos = me->globalPosition().toPoint();
+#else
+        QPoint mousePos = me->screenPos().toPoint();
+#endif
 
         // calculate distances from mouse pos to each handle,
         // then choose to interact with the nearest handle
@@ -556,7 +566,12 @@ bool DDesktopInputSelectionControl::eventFilter(QObject *object, QEvent *event)
                 m_otherSelectionPoint = QPoint(otherRect.x() + otherRect.width() / 2, otherRect.bottom() + 4);
             }
 
-            QMouseEvent *mouseEvent = new QMouseEvent(me->type(), me->localPos(), me->windowPos(), me->screenPos(),
+            QMouseEvent *mouseEvent = new QMouseEvent(me->type(), 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+                                                      me->position(), me->scenePosition(), me->globalPosition(),
+#else
+                                                      me->localPos(), me->windowPos(), me->screenPos(),
+#endif
                                                       me->button(), me->buttons(), me->modifiers(), me->source());
             m_eventQueue.append(mouseEvent);
             return true;
@@ -570,7 +585,11 @@ bool DDesktopInputSelectionControl::eventFilter(QObject *object, QEvent *event)
         m_handleVisible = true;
 
         QMouseEvent *me = static_cast<QMouseEvent *>(event);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        QPoint mousePos = me->globalPosition().toPoint();
+#else
         QPoint mousePos = me->screenPos().toPoint();
+#endif
         if (m_handleState == HandleIsHeld) {
             QPoint delta = m_handleDragStartedPosition - mousePos;
             const int startDragDistance = QGuiApplication::styleHints()->startDragDistance();

--- a/src/dnativesettings.h
+++ b/src/dnativesettings.h
@@ -17,7 +17,7 @@
 DPP_BEGIN_NAMESPACE
 
 class DPlatformSettings;
-class DNativeSettings : public QAbstractDynamicMetaObject
+class Q_DECL_HIDDEN DNativeSettings : public QAbstractDynamicMetaObject
 {
 public:
     explicit DNativeSettings(QObject *base, DPlatformSettings *settings, bool global_settings);

--- a/src/dplatformsettings.h
+++ b/src/dplatformsettings.h
@@ -15,7 +15,7 @@ QT_END_NAMESPACE
 
 DPP_BEGIN_NAMESPACE
 
-class DPlatformSettings
+class Q_DECL_HIDDEN DPlatformSettings
 {
 public:
     virtual ~DPlatformSettings() {}
@@ -41,6 +41,7 @@ protected:
     void handlePropertyChanged(const QByteArray &property, const QVariant &value);
     void handleNotify(const QByteArray &signal, qint32 data1, qint32 data2);
 
+private:
     struct Q_DECL_HIDDEN Callback
     {
         PropertyChangeFunc func;

--- a/src/dselectedtexttooltip.cpp
+++ b/src/dselectedtexttooltip.cpp
@@ -36,7 +36,12 @@ DSelectedTextTooltip::DSelectedTextTooltip()
     m_textInfoVec.push_back({Paste, 0, qApp->translate("QLineEdit", "&Paste").split("(").at(0)});
 
     updateColor();
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    // Qt6中使用事件处理替代fontChanged信号
+    qApp->installEventFilter(this);
+#else
     connect(qApp, &QGuiApplication::fontChanged, this, &DSelectedTextTooltip::onFontChanged);
+#endif
 
     // 更新文本信息
     onFontChanged();
@@ -45,6 +50,16 @@ DSelectedTextTooltip::DSelectedTextTooltip()
 DSelectedTextTooltip::~DSelectedTextTooltip()
 {
 }
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+bool DSelectedTextTooltip::eventFilter(QObject *obj, QEvent *event)
+{
+    if (event->type() == QEvent::ApplicationFontChange) {
+        onFontChanged();
+    }
+    return QRasterWindow::eventFilter(obj, event);
+}
+#endif
 
 void DSelectedTextTooltip::onFontChanged()
 {

--- a/src/dselectedtexttooltip.h
+++ b/src/dselectedtexttooltip.h
@@ -31,6 +31,9 @@ public:
 protected:
     void paintEvent(QPaintEvent *pe) override;
     void mousePressEvent(QMouseEvent *event) override;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    bool eventFilter(QObject *obj, QEvent *event) override;
+#endif
 
 private slots:
     void onFontChanged();

--- a/src/dxcbxsettings.cpp
+++ b/src/dxcbxsettings.cpp
@@ -405,7 +405,11 @@ public:
             const QByteArray &key = i.key();
             quint16 key_size = key.size();
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            switch (value.value.typeId()) {
+#else
             switch (value.value.type()) {
+#endif
             case QMetaType::QColor:
                 type = XSettingsTypeColor;
                 break;

--- a/src/dxcbxsettings.h
+++ b/src/dxcbxsettings.h
@@ -21,7 +21,7 @@ DPP_BEGIN_NAMESPACE
 
 class DXcbXSettingsPrivate;
 
-class DXcbXSettings : public DPlatformSettings
+class Q_DECL_HIDDEN DXcbXSettings : public DPlatformSettings
 {
     Q_DECLARE_PRIVATE(DXcbXSettings)
 public:

--- a/xcb/dframewindow.cpp
+++ b/xcb/dframewindow.cpp
@@ -515,23 +515,41 @@ void DFrameWindow::mouseMoveEvent(QMouseEvent *event)
     }
 set_edge:
     /// begin set cursor edge type
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    if (event->position().x() <= m_contentGeometry.x()) {
+#else
     if (event->x() <= m_contentGeometry.x()) {
+#endif
         if (isFixedWidth)
             goto skip_set_cursor;
 
         mouseCorner = Utility::LeftEdge;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    } else if (event->position().x() < m_contentGeometry.right()) {
+#else
     } else if (event->x() < m_contentGeometry.right()) {
+#endif
         if (isFixedHeight)
             goto skip_set_cursor;
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        if (event->position().y() <= m_contentGeometry.y()) {
+            mouseCorner = Utility::TopEdge;
+        } else if (!isFixedWidth || event->position().y() >= m_contentGeometry.bottom()) {
+#else
         if (event->y() <= m_contentGeometry.y()) {
             mouseCorner = Utility::TopEdge;
         } else if (!isFixedWidth || event->y() >= m_contentGeometry.bottom()) {
+#endif
             mouseCorner = Utility::BottomEdge;
         } else {
             goto skip_set_cursor;
         }
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    } else if (!isFixedWidth && (!isFixedHeight || event->position().x() >= m_contentGeometry.right())) {
+#else
     } else if (!isFixedWidth && (!isFixedHeight || event->x() >= m_contentGeometry.right())) {
+#endif
         mouseCorner = Utility::RightEdge;
     } else {
         goto skip_set_cursor;

--- a/xcb/dnotitlebarwindowhelper.cpp
+++ b/xcb/dnotitlebarwindowhelper.cpp
@@ -559,11 +559,19 @@ bool DNoTitlebarWindowHelper::windowEvent(QEvent *event)
 #endif
     }
     if (isTouchDown && event->type() == QEvent::MouseButtonPress) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        touchBeginPosition = static_cast<QMouseEvent*>(event)->globalPosition().toPoint();
+#else
         touchBeginPosition = static_cast<QMouseEvent*>(event)->globalPos();
+#endif
     }
     // add some redundancy to distinguish trigger between system menu and system move
     if (event->type() == QEvent::MouseMove) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        QPointF currentPos = static_cast<QMouseEvent*>(event)->globalPosition();
+#else
         QPointF currentPos = static_cast<QMouseEvent*>(event)->globalPos();
+#endif
         QPointF delta = touchBeginPosition  - currentPos;
         if (delta.manhattanLength() < QGuiApplication::styleHints()->startDragDistance()) {
             return VtableHook::callOriginalFun(w, &QWindow::event, event);
@@ -590,7 +598,11 @@ bool DNoTitlebarWindowHelper::windowEvent(QEvent *event)
     // keeping the moving state, we can just reset ti back to normal.
     if (event->type() == QEvent::MouseButtonPress) {
         self->m_windowMoving = false;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        g_pressPoint[this] = dynamic_cast<QMouseEvent*>(event)->globalPosition().toPoint();
+#else
         g_pressPoint[this] = dynamic_cast<QMouseEvent*>(event)->globalPos();
+#endif
     }
 
     // ========== 修改：鼠标事件处理保持原有逻辑 ==========
@@ -605,7 +617,11 @@ bool DNoTitlebarWindowHelper::windowEvent(QEvent *event)
             return ret;
         }
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        QPointF delta = me->globalPosition() - g_pressPoint[this];
+#else
         QPointF delta = me->globalPos() - g_pressPoint[this];
+#endif
         if (delta.manhattanLength() < QGuiApplication::styleHints()->startDragDistance()) {
             return ret;
         }

--- a/xcb/dplatformwindowhelper.cpp
+++ b/xcb/dplatformwindowhelper.cpp
@@ -559,7 +559,11 @@ bool DPlatformWindowHelper::windowRedirectContent(QWindow *window)
 
     const QVariant &value = window->property(redirectContent);
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    if (value.typeId() == QMetaType::Bool)
+#else
     if (value.type() == QVariant::Bool)
+#endif
         return value.toBool();
 
     return window->surfaceType() == QSurface::OpenGLSurface;
@@ -612,7 +616,11 @@ bool DPlatformWindowHelper::eventFilter(QObject *watched, QEvent *event)
         case QEvent::MouseMove: {
             DQMouseEvent *e = static_cast<DQMouseEvent*>(event);
             const QRectF rectF(m_windowValidGeometry);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            const QPointF posF(e->position() - m_frameWindow->contentOffsetHint());
+#else
             const QPointF posF(e->localPos() - m_frameWindow->contentOffsetHint());
+#endif
 
             // QRectF::contains中判断时加入了右下边界
             if (!qFuzzyCompare(posF.x(), rectF.width())


### PR DESCRIPTION
1. Added Qt6 version checks for touch/mouse event handling with new API
(globalPosition vs screenPos)
2. Marked DNativeSettings, DPlatformSettings and DXcbXSettings classes
as Q_DECL_HIDDEN
3. Replaced QGuiApplication::fontChanged signal with event filter for
Qt6 compatibility
4. Updated type checking from QVariant::type() to typeId() for Qt6
5. Fixed window geometry calculations for Qt6 mouse position handling
6. Adjusted DHighDpi initialization logic for Qt6 where high DPI is
always enabled
7. Added proper private section to DPlatformSettings class

fix: 添加Qt6兼容性并解决编译警告

1. 为触摸/鼠标事件处理添加Qt6版本检查，使用新API（globalPosition替
代screenPos）
2. 将DNativeSettings、DPlatformSettings和DXcbXSettings类标记为
Q_DECL_HIDDEN
3. 为Qt6兼容性使用事件过滤器替代QGuiApplication::fontChanged信号
4. 将类型检查从QVariant::type()更新为typeId()以兼容Qt6
5. 修复Qt6鼠标位置处理的窗口几何计算
6. 调整DHighDpi初始化逻辑以适应Qt6中始终启用高DPI的情况
7. 为DPlatformSettings类添加适当的私有部分
