### PR TITLE
fix: resolve various compiler warnings

### DIFF
--- a/src/dbackingstoreproxy.cpp
+++ b/src/dbackingstoreproxy.cpp
@@ -308,7 +308,6 @@ void DBackingStoreProxy::updateWallpaperShared()
     const qint32 *header = reinterpret_cast<const qint32*>(m_sharedMemory->constData());
     const uchar *content = reinterpret_cast<const uchar*>(m_sharedMemory->constData()) + HEADER_SIZE;
 
-    qint32 byte_count = header[0];
     qint32 image_width = header[1];
     qint32 image_height = header[2];
     qint32 image_format = header[3];

--- a/src/ddesktopinputselectioncontrol.cpp
+++ b/src/ddesktopinputselectioncontrol.cpp
@@ -127,7 +127,7 @@ QRect DDesktopInputSelectionControl::cursorHandleRect() const
     return handleRectForCursorRect(cursorRectangle());
 }
 
-static int getInputRectangleY(const QPoint &pos)
+[[maybe_unused]] static int getInputRectangleY(const QPoint &pos)
 {
     // 保证handle不会超出TextEdit类输入框
     int posY = pos.y();

--- a/src/dnativesettings.h
+++ b/src/dnativesettings.h
@@ -17,7 +17,7 @@
 DPP_BEGIN_NAMESPACE
 
 class DPlatformSettings;
-class Q_DECL_HIDDEN DNativeSettings : public QAbstractDynamicMetaObject
+class DNativeSettings : public QAbstractDynamicMetaObject
 {
 public:
     explicit DNativeSettings(QObject *base, DPlatformSettings *settings, bool global_settings);

--- a/src/dplatformsettings.h
+++ b/src/dplatformsettings.h
@@ -15,7 +15,7 @@ QT_END_NAMESPACE
 
 DPP_BEGIN_NAMESPACE
 
-class Q_DECL_HIDDEN DPlatformSettings
+class DPlatformSettings
 {
 public:
     virtual ~DPlatformSettings() {}
@@ -42,13 +42,13 @@ protected:
     void handleNotify(const QByteArray &signal, qint32 data1, qint32 data2);
 
 private:
-    struct Q_DECL_HIDDEN Callback
+    struct Callback
     {
         PropertyChangeFunc func;
         void *handle;
     };
 
-    struct Q_DECL_HIDDEN SignalCallback
+    struct SignalCallback
     {
         SignalFunc func;
         void *handle;

--- a/src/dxcbxsettings.cpp
+++ b/src/dxcbxsettings.cpp
@@ -48,7 +48,7 @@ static xcb_atom_t internAtom(xcb_connection_t *conn, const char *name)
     return atom;
 }
 
-static QByteArray atomName(xcb_connection_t *conn, xcb_atom_t atom)
+[[maybe_unused]] static QByteArray atomName(xcb_connection_t *conn, xcb_atom_t atom)
 {
     xcb_get_atom_name_cookie_t cookie = xcb_get_atom_name(conn, atom);
     xcb_get_atom_name_reply_t *reply = xcb_get_atom_name_reply(conn, cookie, nullptr);
@@ -169,9 +169,12 @@ class Q_DECL_HIDDEN DXcbXSettingsPrivate
 {
 public:
     DXcbXSettingsPrivate(xcb_connection_t *connection, const QByteArray &property, DXcbXSettings *qq)
-        : connection(connection)
+        : q_ptr(qq)
+        , connection(connection)
+        , x_settings_window(0)
+        , x_settings_atom(0)
+        , serial(-1)
         , initialized(false)
-        , q_ptr(qq)
     {
         if (property.isEmpty()) {
             x_settings_atom = internAtom(connection, "_XSETTINGS_SETTINGS");

--- a/src/dxcbxsettings.h
+++ b/src/dxcbxsettings.h
@@ -21,7 +21,7 @@ DPP_BEGIN_NAMESPACE
 
 class DXcbXSettingsPrivate;
 
-class Q_DECL_HIDDEN DXcbXSettings : public DPlatformSettings
+class DXcbXSettings : public DPlatformSettings
 {
     Q_DECLARE_PRIVATE(DXcbXSettings)
 public:

--- a/src/vtablehook.h
+++ b/src/vtablehook.h
@@ -95,7 +95,7 @@ public:
         quintptr fun1_offset = toQuintptr(&fun1);
         quintptr fun2_offset = toQuintptr(&fun2);
 
-        if (fun1_offset < 0 || fun1_offset > UINT_LEAST16_MAX)
+        if (fun1_offset > UINT_LEAST16_MAX)
             return false;
 
         quintptr *vfun = vfptr_t1 + fun1_offset / sizeof(quintptr);
@@ -180,7 +180,7 @@ public:
         quintptr fun1_offset = toQuintptr(&fun1);
         quintptr fun2_offset = toQuintptr(&fun2);
 
-        if (fun1_offset < 0 || fun1_offset > UINT_LEAST16_MAX)
+        if (fun1_offset > UINT_LEAST16_MAX)
             return false;
 
         quintptr *vfun = vfptr_t1 + fun1_offset / sizeof(quintptr);

--- a/tests/src/ut_dnativesettings.cpp
+++ b/tests/src/ut_dnativesettings.cpp
@@ -9,11 +9,11 @@
 
 DPP_USE_NAMESPACE
 
-class TDNativeSettings : public testing::Test
+class GTEST_API_ TDNativeSettings : public testing::Test
 {
 protected:
-    void SetUp();
-    void TearDown();
+    void SetUp() override;
+    void TearDown() override;
 
     QWindow *window = nullptr;
 };

--- a/tests/src/ut_dxcbxsettings.cpp
+++ b/tests/src/ut_dxcbxsettings.cpp
@@ -20,7 +20,7 @@ static void propertyChangedfunc(xcb_connection_t *, const QByteArray &, const QV
     testPropertyChangedCallback = true;
 }
 
-class TDXcbXSettings : public testing::Test
+class GTEST_API_ TDXcbXSettings : public testing::Test
 {
 protected:
     void SetUp();

--- a/wayland/dwayland/dhighdpi.cpp
+++ b/wayland/dwayland/dhighdpi.cpp
@@ -159,6 +159,7 @@ void DHighDpi::removeScreenFactorCache(QScreen *screen)
     } else {
         screenFactorMap.clear();
 #else
+    Q_UNUSED(screen)
     {
 #endif
         // 刷新所有窗口

--- a/wayland/dwayland/dwaylandinterfacehook.cpp
+++ b/wayland/dwayland/dwaylandinterfacehook.cpp
@@ -247,7 +247,8 @@ bool DWaylandInterfaceHook::supportForSplittingWindowByType(quint32 wid, quint32
     if(!window || !window->handle())
         return false;
     DNoTitlebarWlWindowHelper::setWindowProperty(window, ::supportForSplittingWindow, false);
-    return window->property(::supportForSplittingWindow).toInt() >= screenSplittingType;
+    int propertyValue = window->property(::supportForSplittingWindow).toInt();
+    return propertyValue >= 0 && static_cast<quint32>(propertyValue) >= screenSplittingType;
 }
 
 DPP_END_NAMESPACE

--- a/wayland/wayland-shell/dwaylandshellmanager.cpp
+++ b/wayland/wayland-shell/dwaylandshellmanager.cpp
@@ -144,6 +144,8 @@ static void checkIsDWayland(const QString &function)
 {
 #ifndef D_DEEPIN_IS_DWAYLAND
     qCWarning(dwlp) << "This package is not compiled as dwayland, and [" << function << "] not support in this version.";
+#else
+    Q_UNUSED(function)
 #endif
 }
 

--- a/xcb/dhighdpi.cpp
+++ b/xcb/dhighdpi.cpp
@@ -155,13 +155,14 @@ qreal DHighDpi::devicePixelRatio(QPlatformWindow *w)
 
 void DHighDpi::onDPIChanged(xcb_connection_t *connection, const QByteArray &name, const QVariant &property, void *handle)
 {
+    Q_UNUSED(connection)
+    Q_UNUSED(name)
+    Q_UNUSED(handle)
+    
     static bool dynamic_dpi = qEnvironmentVariableIsSet("D_DXCB_RT_HIDPI");
 
     if (!dynamic_dpi)
         return;
-
-    Q_UNUSED(connection)
-    Q_UNUSED(name)
 
     // 判断值是否有效
     if (!property.isValid())

--- a/xcb/dplatformbackingstorehelper.cpp
+++ b/xcb/dplatformbackingstorehelper.cpp
@@ -10,7 +10,9 @@
 
 #ifdef Q_OS_LINUX
 #define private public
+#define protected public
 #include "qxcbbackingstore.h"
+#undef protected
 #undef private
 #endif
 
@@ -158,12 +160,7 @@ void DPlatformBackingStoreHelper::resize(const QSize &size, const QRegion &stati
     VtableHook::callOriginalFun(this->backingStore(), &QPlatformBackingStore::resize, size, staticContents);
 
     QXcbBackingStore *bs = static_cast<QXcbBackingStore*>(backingStore());
-#if QT_VERSION < QT_VERSION_CHECK(5, 12, 0)
     QXcbShmImage *shm_image = reinterpret_cast<QXcbShmImage*>(bs->m_image);
-#else
-    struct _QXcbBackingStore { QImage *m_image; }; // Expose m_image
-    QXcbShmImage *shm_image = reinterpret_cast<QXcbShmImage*>(reinterpret_cast<_QXcbBackingStore*>( &bs )->m_image);
-#endif
 
     if (shm_image->m_shm_info.shmaddr) {
         DPlatformWindowHelper *window_helper = DPlatformWindowHelper::mapped.value(bs->window()->handle());

--- a/xcb/dplatformintegration.cpp
+++ b/xcb/dplatformintegration.cpp
@@ -873,7 +873,7 @@ static bool updateCursorTheme(void *dpy)
     return setTheme;
 }
 
-static xcb_cursor_t overrideCreateFontCursor(QXcbCursor *xcb_cursor, QCursor *c, QWindow *window)
+[[maybe_unused]] static xcb_cursor_t overrideCreateFontCursor(QXcbCursor *xcb_cursor, QCursor *c, QWindow *window)
 {
     const Qt::CursorShape cshape = c->shape();
     xcb_connection_t *conn = xcb_cursor->xcb_connection();
@@ -944,6 +944,7 @@ static void overrideChangeCursor(QPlatformCursor *cursorHandle, QCursor * cursor
     if (widget->property(disableOverrideCursor).toBool())
         return;
 
+    Q_UNUSED(w) // Variable is used in some Qt versions but not all
 #ifdef D_ENABLE_CURSOR_HOOK
     // set cursor size scale
     static bool xcursrSizeIsSet = qEnvironmentVariableIsSet("XCURSOR_SIZE");


### PR DESCRIPTION
Fixed multiple compiler warnings across the codebase including:
1. Removed unused variable 'byte_count' in DBackingStoreProxy
2. Added [[maybe_unused]] attribute to unused functions
getInputRectangleY and atomName
3. Removed Q_DECL_HIDDEN from several class declarations
4. Fixed initialization order in DXcbXSettingsPrivate constructor
5. Removed negative check for function pointer offset in VtableHook
6. Added override keyword to test class methods
7. Added Q_UNUSED for unused parameters in various functions
8. Fixed potential integer comparison issues in DWaylandInterfaceHook
9. Added proper type casting for window property comparison
10. Fixed Qt version conditional compilation in
DPlatformBackingStoreHelper

These changes improve code quality by:
- Removing dead code
- Making unused function intentions explicit
- Following modern C++ practices
- Ensuring proper initialization order
- Preventing potential integer comparison issues
- Maintaining cross-version Qt compatibility

Influence:
1. Verify wallpaper sharing functionality still works
2. Test input handling in text fields
3. Validate platform settings behavior
4. Check XSettings integration
5. Test vtable hooking functionality
6. Verify unit tests still pass
7. Test wayland window splitting functionality
8. Validate high DPI scaling behavior

fix: 修复各种编译器警告

修复了代码库中的多个编译器警告，包括：
1. 移除DBackingStoreProxy中未使用的变量'byte_count'
2. 为未使用的函数getInputRectangleY和atomName添加[[maybe_unused]]属性
3. 从多个类声明中移除Q_DECL_HIDDEN
4. 修复DXcbXSettingsPrivate构造函数中的初始化顺序
5. 移除VtableHook中对函数指针偏移量的负值检查
6. 为测试类方法添加override关键字
7. 为多个未使用的参数添加Q_UNUSED
8. 修复DWaylandInterfaceHook中潜在的整数比较问题
9. 为窗口属性比较添加适当的类型转换
10. 修复DPlatformBackingStoreHelper中的Qt版本条件编译

这些改进通过以下方式提升代码质量：
- 移除无用代码
- 明确未使用函数的意图
- 遵循现代C++实践
- 确保正确的初始化顺序
- 防止潜在的整数比较问题
- 保持跨Qt版本的兼容性

Influence:
1. 验证壁纸共享功能是否仍然正常工作
2. 测试文本字段中的输入处理
3. 验证平台设置行为
4. 检查XSettings集成
5. 测试vtable钩子功能
6. 验证单元测试是否仍然通过
7. 测试wayland窗口分割功能
8. 验证高DPI缩放行为
