### PR TITLE
feat: add window edge margin detection for gesture conflict prevention

### DIFF
--- a/src/global.cpp
+++ b/src/global.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2022 Uniontech Software Technology Co.,Ltd.
+// SPDX-FileCopyrightText: 2017 - 2026 Uniontech Software Technology Co.,Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -35,6 +35,19 @@ void RunInThreadProxy::proxyCall(FunctionType func)
     connect(&scope, &QObject::destroyed, receiver, [func]() {
         (func)();
     }, Qt::QueuedConnection);
+}
+
+// 判断起始按压点是否在窗口左/右/下边缘的手势保护区内
+bool isInEdgeMargin(const QPoint &pressLocalPos, const QSize &windowSize)
+{
+    static int margin = []() {
+        bool ok;
+        int v = qEnvironmentVariableIntValue("D_DXCB_EDGE_MARGIN", &ok);
+        return (ok && v >= 0) ? v : 5;
+    }();
+    return pressLocalPos.x() < margin
+        || pressLocalPos.x() >= windowSize.width() - margin
+        || pressLocalPos.y() >= windowSize.height() - margin;
 }
 
 DPP_END_NAMESPACE

--- a/src/global.h
+++ b/src/global.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2022 Uniontech Software Technology Co.,Ltd.
+// SPDX-FileCopyrightText: 2017 - 2026 Uniontech Software Technology Co.,Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -134,5 +134,8 @@ public:
     void proxyCall(FunctionType func);
 
 };
+
+bool isInEdgeMargin(const QPoint &pressLocalPos, const QSize &windowSize);
+
 DPP_END_NAMESPACE
 #endif // GLOBAL_H

--- a/wayland/dwayland/dnotitlebarwindowhelper_wl.cpp
+++ b/wayland/dwayland/dnotitlebarwindowhelper_wl.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2022 Uniontech Software Technology Co.,Ltd.
+// SPDX-FileCopyrightText: 2017 - 2026 Uniontech Software Technology Co.,Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -196,6 +196,12 @@ bool DNoTitlebarWlWindowHelper::windowEvent(QWindow *w, QEvent *event)
 
     if (is_mouse_move && !event->isAccepted()
             && w->geometry().contains(static_cast<QMouseEvent*>(event)->globalPos())) {
+        // 用按下时的起始点（本地坐标）做边缘检查，避免与系统手势冲突
+        QPoint localStartPos = w->mapFromGlobal(static_cast<QMouseEvent*>(event)->globalPos());
+        if (isInEdgeMargin(localStartPos, w->size())) {
+            return false;
+        }
+
         if (!self->m_windowMoving && self->isEnableSystemMove()) {
             self->m_windowMoving = true;
 

--- a/xcb/dnotitlebarwindowhelper.cpp
+++ b/xcb/dnotitlebarwindowhelper.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2022 Uniontech Software Technology Co.,Ltd.
+// SPDX-FileCopyrightText: 2017 - 2026 Uniontech Software Technology Co.,Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -617,6 +617,12 @@ bool DNoTitlebarWindowHelper::windowEvent(QEvent *event)
             return ret;
         }
 
+        // 用按下时的起始点（本地坐标）做边缘检查，避免与系统手势冲突
+        QPoint localStartPos = w->mapFromGlobal(g_pressPoint[this].toPoint());
+        if (isInEdgeMargin(localStartPos, w->size())) {
+            return ret;
+        }
+
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
         QPointF delta = me->globalPosition() - g_pressPoint[this];
 #else
@@ -865,6 +871,10 @@ bool DNoTitlebarWindowHelper::handleTouchDragForQML(QPointerEvent *touchEvent)
             
             // 使用本地坐标检查（更可靠）
             if (!inBounds) {
+                return false;
+            }
+            QPoint localStartPos = w->mapFromGlobal(startPos.toPoint());
+            if (isInEdgeMargin(localStartPos, w->size())) {
                 return false;
             }
             


### PR DESCRIPTION
1. Added isInEdgeMargin function to detect if press point is within
window edge margins
2. Implemented edge margin detection for both Wayland and X11 window
systems
3. Added environment variable D_DXCB_EDGE_MARGIN to configure margin
size (default 5 pixels)
4. Prevent window drag operations when press starts within edge margins
to avoid conflicts with system gestures

Log: Added window edge margin detection to prevent conflicts with system
gestures during window dragging

Influence:
1. Test window dragging from different positions to ensure normal
operation
2. Test dragging from window edges to verify gesture conflict prevention
3. Verify edge margin configuration via D_DXCB_EDGE_MARGIN environment
variable
4. Test both mouse and touch interactions on Wayland and X11 platforms
5. Verify window resize functionality is not affected by edge margin
detection

feat: 添加窗口边缘检测功能防止手势冲突

1. 新增 isInEdgeMargin 函数检测按压点是否在窗口边缘区域内
2. 在 Wayland 和 X11 窗口系统中实现边缘检测功能
3. 添加 D_DXCB_EDGE_MARGIN 环境变量配置边缘区域大小（默认5像素）
4. 当按压起始点在边缘区域内时阻止窗口拖拽操作，避免与系统手势冲突

Log: 新增窗口边缘检测功能，防止窗口拖拽时与系统手势冲突

Influence:
1. 测试从不同位置拖拽窗口，确保正常操作不受影响
2. 测试从窗口边缘开始拖拽，验证手势冲突预防功能
3. 通过 D_DXCB_EDGE_MARGIN 环境变量验证边缘区域配置
4. 在 Wayland 和 X11 平台上测试鼠标和触摸交互
5. 验证窗口调整大小功能不受边缘检测影响
